### PR TITLE
Add a new migration order sanity check.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /dist-newstyle/
 cabal.project.local
+.ghc.environment.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# hpqtypes-extras-1.3.1.0 (2017-07-20)
+* Imporved migration order sanity checking (#7).
+
 # hpqtypes-extras-1.3.0.0 (2017-05-17)
 * Add drop table migrations.
 * Add a test suite.

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -98,6 +98,7 @@ test-suite  hpqtypes-extras-tests
                       hpqtypes-extras,
                       lifted-base,
                       log,
+                      monad-control,
                       tasty,
                       tasty-hunit,
                       text,

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -1,5 +1,5 @@
 name:                hpqtypes-extras
-version:             1.3.0.0
+version:             1.3.1.0
 synopsis:            Extra utilities for hpqtypes library
 description:         The following extras for hpqtypes library:
                      .


### PR DESCRIPTION
Check that `mgrFrom . head` (the expected version) for each chain of migrations we're going to run is the same as the version number of that table in the actual DB.

[Case 3242](https://scrive.fogbugz.com/f/cases/3242/Sanity-check-in-hpqtypes-extras-appears-to-be-buggy).