### PR TITLE
Improve handling of (multiple column) primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# hpqtypes-extras-1.5.0.0 (2017-12-05)
+* Changed internal representation of PrimaryKey to NubList (#11)
+  This will break existing PKs set on multiple columns unless they are
+  alphabetically sorted in the defining list.
+
 # hpqtypes-extras-1.4.0.0 (2017-11-24)
 * Introduced tsvector postgres type and indexing methods GIN and BTree
 

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -1,5 +1,5 @@
 name:                hpqtypes-extras
-version:             1.4.0.0
+version:             1.5.0.0
 synopsis:            Extra utilities for hpqtypes library
 description:         The following extras for hpqtypes library:
                      .
@@ -51,6 +51,7 @@ library
   build-depends: base < 5
                , base16-bytestring
                , bytestring
+               , Cabal
                , containers
                , cryptohash
                , exceptions

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -47,11 +47,11 @@ library
                  , Database.PostgreSQL.PQTypes.SQL.Builder
                  , Database.PostgreSQL.PQTypes.Versions
   other-modules:   Database.PostgreSQL.PQTypes.Checks.Util
+                 , Database.PostgreSQL.PQTypes.Utils.NubList
 
   build-depends: base < 5
                , base16-bytestring
                , bytestring
-               , Cabal
                , containers
                , cryptohash
                , exceptions

--- a/src/Database/PostgreSQL/PQTypes/Model/PrimaryKey.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/PrimaryKey.hs
@@ -11,17 +11,17 @@ import Data.Monoid (mconcat)
 import Data.Monoid.Utils
 import Database.PostgreSQL.PQTypes
 import Prelude
-import qualified Data.Set as S
+import Distribution.Utils.NubList
 
-newtype PrimaryKey = PrimaryKey (S.Set (RawSQL ()))
-  deriving (Eq, Ord, Show)
+newtype PrimaryKey = PrimaryKey (NubList (RawSQL ()))
+  deriving (Eq, Show)
 
 pkOnColumn :: RawSQL () -> Maybe PrimaryKey
-pkOnColumn = Just . PrimaryKey . S.singleton
+pkOnColumn column = Just . PrimaryKey . toNubList $ [column]
 
 pkOnColumns :: [RawSQL ()] -> Maybe PrimaryKey
 pkOnColumns []      = Nothing
-pkOnColumns columns = Just . PrimaryKey . S.fromList $ columns
+pkOnColumns columns = Just . PrimaryKey . toNubList $ columns
 
 pkName :: RawSQL () -> RawSQL ()
 pkName tname = mconcat ["pk__", tname]
@@ -31,7 +31,7 @@ sqlAddPK tname (PrimaryKey columns) = smconcat [
     "ADD CONSTRAINT"
   , pkName tname
   , "PRIMARY KEY ("
-  , mintercalate ", " $ S.toAscList columns
+  , mintercalate ", " $ fromNubList columns
   , ")"
   ]
 

--- a/src/Database/PostgreSQL/PQTypes/Model/PrimaryKey.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/PrimaryKey.hs
@@ -11,7 +11,7 @@ import Data.Monoid (mconcat)
 import Data.Monoid.Utils
 import Database.PostgreSQL.PQTypes
 import Prelude
-import Distribution.Utils.NubList
+import Database.PostgreSQL.PQTypes.Utils.NubList
 
 newtype PrimaryKey = PrimaryKey (NubList (RawSQL ()))
   deriving (Eq, Show)

--- a/src/Database/PostgreSQL/PQTypes/Utils/NubList.hs
+++ b/src/Database/PostgreSQL/PQTypes/Utils/NubList.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+module Database.PostgreSQL.PQTypes.Utils.NubList
+    ( NubList    -- opaque
+    , toNubList  -- smart construtor
+    , fromNubList
+    , overNubList
+    ) where
+
+import Prelude
+import Data.Monoid (Monoid(..))
+import Data.Typeable
+
+import qualified Text.Read as R
+import qualified Data.Set as Set
+
+{-
+  This module is a copy-paste fork of Distribution.Utils.NubList in Cabal
+  (Cabal-2.0.1.1 as it happens) to avoid depending on the whole of the Cabal
+  library. `NubListR` was removed in the process and `ordNubBy` and `listUnion`
+  hand-inlined to avoid depending on more Cabal-specific modules.
+-}
+
+-- | NubList : A de-duplicated list that maintains the original order.
+newtype NubList a =
+    NubList { fromNubList :: [a] }
+    deriving (Eq, Typeable)
+
+-- NubList assumes that nub retains the list order while removing duplicate
+-- elements (keeping the first occurence). Documentation for "Data.List.nub"
+-- does not specifically state that ordering is maintained so we will add a test
+-- for that to the test suite.
+
+-- | Smart constructor for the NubList type.
+toNubList :: Ord a => [a] -> NubList a
+toNubList list = NubList $ (ordNubBy id) list
+
+-- | Lift a function over lists to a function over NubLists.
+overNubList :: Ord a => ([a] -> [a]) -> NubList a -> NubList a
+overNubList f (NubList list) = toNubList . f $ list
+
+instance Ord a => Monoid (NubList a) where
+    mempty = NubList []
+    (NubList xs) `mappend` (NubList ys) = NubList $ xs `listUnion` ys
+      where listUnion :: (Ord a) => [a] -> [a] -> [a]
+            listUnion a b = a ++ (ordNubBy id) (filter (`Set.notMember` (Set.fromList a)) b)
+
+instance Show a => Show (NubList a) where
+    show (NubList list) = show list
+
+instance (Ord a, Read a) => Read (NubList a) where
+    readPrec = readNubList toNubList
+
+-- | Helper used by NubList/NubListR's Read instances.
+readNubList :: (Read a) => ([a] -> l a) -> R.ReadPrec (l a)
+readNubList toList = R.parens . R.prec 10 $ fmap toList R.readPrec
+
+ordNubBy :: Ord b => (a -> b) -> [a] -> [a]
+ordNubBy f l = go Set.empty l
+  where
+    go !_ [] = []
+    go !s (x:xs)
+      | y `Set.member` s = go s xs
+      | otherwise        = let !s' = Set.insert y s
+                            in x : go s' xs
+      where
+        y = f x


### PR DESCRIPTION
Adresses issue #11. 

Bumping version to `1.5.0.0` due to the fact that while it is true that the internal representation of a `PrimaryKey` isn't visible, its observable behaviour is radically different (i.e. retains order of columns as written in the argument list to `pkOnColumns`).