### PR TITLE
Changed `getDBTableNames` to use `current_schemas(boolean)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# hpqtypes-extras-1.5.0.1 (2018-01-09)
+* Changed `getDBTableNames` to only schemas explicitly in search path, rather
+  than an exclusion list. Affects table version and unknown tables checks.
+
 # hpqtypes-extras-1.5.0.0 (2017-12-08)
 * Changed internal representation of PrimaryKey to NubList (#11)
   This will break existing PKs set on multiple columns unless they are

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -1,5 +1,5 @@
 name:                hpqtypes-extras
-version:             1.5.0.0
+version:             1.5.0.1
 synopsis:            Extra utilities for hpqtypes library
 description:         The following extras for hpqtypes library:
                      .

--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -157,7 +157,9 @@ getDBTableNames = do
     sqlResult "table_name::text"
     sqlWhere "table_name <> 'table_versions'"
     sqlWhere "table_type = 'BASE TABLE'"
-    sqlWhere "table_schema NOT IN ('information_schema','pg_catalog')"
+    sqlWhereExists $ sqlSelect "unnest(current_schemas(false)) as cs" $ do
+      sqlResult "TRUE"
+      sqlWhere "cs = table_schema"
 
   dbTableNames <- fetchMany runIdentity
   return dbTableNames


### PR DESCRIPTION
Affects table version and unknown tables checks.
CORE-241

@bugthunk I did not compile or run this! So we should check that first :)