### PR TITLE
Fix an issue where unnecessary migrations were run sometimes (1.6 backport)

### DIFF
--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -24,6 +24,7 @@ import Data.Ord (comparing)
 import qualified Data.String
 import Data.Text (Text)
 import Database.PostgreSQL.PQTypes hiding (def)
+import GHC.Stack (HasCallStack)
 import Log
 import Prelude
 import TextShow
@@ -456,7 +457,7 @@ checkDBConsistency options domains tables migrations = do
 
   where
 
-    errorInvalidMigrations :: [RawSQL ()] -> a
+    errorInvalidMigrations :: HasCallStack => [RawSQL ()] -> a
     errorInvalidMigrations tblNames =
       error $ "checkDBConsistency: invalid migrations for tables"
               <+> (L.intercalate ", " $ map (T.unpack . unRawSQL) tblNames)

--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -48,7 +48,8 @@ migrateDatabase
   :: (MonadDB m, MonadLog m, MonadThrow m)
   => ExtrasOptions -> [Extension] -> [Domain] -> [Table] -> [Migration m]
   -> m ()
-migrateDatabase options@ExtrasOptions{..} extensions domains tables migrations = do
+migrateDatabase options@ExtrasOptions{..}
+  extensions domains tables migrations = do
   setDBTimeZoneToUTC
   mapM_ checkExtension extensions
   -- 'checkDBConsistency' also performs migrations.
@@ -204,7 +205,8 @@ checkExistenceOfVersionsForTables tables = do
   if (not . null $ absent) || (not . null $ notPresent)
     then do
     mapM_ (logInfo_ . (<+>) "Unknown entry in 'table_versions':") absent
-    mapM_ (logInfo_ . (<+>) "Table not present in the 'table_versions':") notPresent
+    mapM_ (logInfo_ . (<+>) "Table not present in the 'table_versions':")
+      notPresent
     return . ValidationResult $
       (joinedResult "Unknown entry in table_versions':"  absent ) ++
       (joinedResult "Tables not present in the 'table_versions':" notPresent)
@@ -318,7 +320,8 @@ checkDBStructure options tables = fmap mconcat . forM tables $ \table ->
         , checkForeignKeys tblForeignKeys fkeys
         ]
       where
-        fetchTableColumn :: (String, ColumnType, Bool, Maybe String) -> TableColumn
+        fetchTableColumn
+          :: (String, ColumnType, Bool, Maybe String) -> TableColumn
         fetchTableColumn (name, ctype, nullable, mdefault) = TableColumn {
             colName = unsafeSQL name
           , colType = ctype
@@ -326,7 +329,8 @@ checkDBStructure options tables = fmap mconcat . forM tables $ \table ->
           , colDefault = unsafeSQL `liftM` mdefault
           }
 
-        checkColumns :: Int -> [TableColumn] -> [TableColumn] -> ValidationResult
+        checkColumns
+          :: Int -> [TableColumn] -> [TableColumn] -> ValidationResult
         checkColumns _ [] [] = mempty
         checkColumns _ rest [] = ValidationResult [tableHasLess "columns" rest]
         checkColumns _ [] rest = ValidationResult [tableHasMore "columns" rest]
@@ -336,8 +340,9 @@ checkDBStructure options tables = fmap mconcat . forM tables $ \table ->
           -- distinction between them after table is created.
           , validateTypes $ colType d == colType c ||
             (colType d == BigSerialT && colType c == BigIntT)
-          -- there is a problem with default values determined by sequences as
-          -- they're implicitely specified by db, so let's omit them in such case
+          -- There is a problem with default values determined by
+          -- sequences as they're implicitly specified by db, so
+          -- let's omit them in such case.
           , validateDefaults $ colDefault d == colDefault c ||
             (colDefault d == Nothing
              && ((T.isPrefixOf "nextval('" . unRawSQL) `liftM` colDefault c)
@@ -494,8 +499,9 @@ checkDBConsistency options domains tables migrations = do
                         <> "and dropped tables is not empty")
             $ object
             [ "intersection" .= map unRawSQL intersection ]
-          errorInvalidMigrations [ tblName tbl | tbl <- tables
-                                               , tblName tbl `elem` intersection ]
+          errorInvalidMigrations [ tblName tbl
+                                 | tbl <- tables
+                                 , tblName tbl `elem` intersection ]
 
       -- Check that if a list of migrations for a given table has a
       -- drop table migration, it is unique and is the last migration
@@ -516,8 +522,9 @@ checkDBConsistency options domains tables migrations = do
         logAttention ("Migration lists for some tables contain "
                       <> "either multiple drop table migrations or "
                       <> "a drop table migration in non-tail position.")
-          $ object [ "tables" .= [ unRawSQL tblName
-                                 | tblName <- tablesWithInvalidMigrationLists ] ]
+          $ object [ "tables" .=
+                     [ unRawSQL tblName
+                     | tblName <- tablesWithInvalidMigrationLists ] ]
         errorInvalidMigrations tablesWithInvalidMigrationLists
 
     createDBSchema :: m ()
@@ -541,7 +548,8 @@ checkDBConsistency options domains tables migrations = do
           initialSetup tis
       logInfo_ "Done."
 
-    -- | Input is a list of (table name, expected version, actual version) triples.
+    -- | Input is a list of (table name, expected version, actual
+    -- version) triples.
     validateMigrationsAgainstDB :: [(RawSQL (), Int32, Int32)] -> m ()
     validateMigrationsAgainstDB tablesWithVersions
       = forM_ tablesWithVersions $ \(tableName, expectedVer, actualVer) ->
@@ -571,7 +579,8 @@ checkDBConsistency options domains tables migrations = do
       forM_ dbTablesToDropWithVersions $ \(tblName, fromVer, ver) ->
         when (fromVer /= ver) $
           -- In case when the table we're going to drop is an old
-          -- version, check that there are migrations that bring it to a new one.
+          -- version, check that there are migrations that bring it to
+          -- a new one.
           validateMigrationsAgainstDB [(tblName, fromVer, ver)]
 
     findMigrationsToRun :: [(Text, Int32)] -> [Migration m]
@@ -582,7 +591,8 @@ checkDBConsistency options domains tables migrations = do
           droppedEventually mgr = mgrTableName mgr `elem` tableNamesToDrop
 
           lookupVer :: Migration m -> Maybe Int32
-          lookupVer mgr = lookup (unRawSQL $ mgrTableName mgr) dbTablesWithVersions
+          lookupVer mgr = lookup (unRawSQL $ mgrTableName mgr)
+                          dbTablesWithVersions
 
           tableDoesNotExist = isNothing . lookupVer
 
@@ -596,7 +606,8 @@ checkDBConsistency options domains tables migrations = do
                  -- table migration and we're not going to drop the
                  -- table afterwards, this is our starting point.
                  Nothing -> not $
-                            (mgrFrom mgr == 0) && (not . droppedEventually $ mgr)
+                            (mgrFrom mgr == 0) &&
+                            (not . droppedEventually $ mgr)
                  -- Table exists in the DB. Run only those migrations
                  -- that have mgrFrom >= table version in the DB.
                  Just ver -> not $
@@ -610,8 +621,8 @@ checkDBConsistency options domains tables migrations = do
           --
           -- Case in point: createTable t, doSomethingTo t,
           -- doSomethingTo t1, dropTable t.
-          l = length migrationsToRun'
-          initialMigrations = drop l $ reverse migrations
+          l                    = length migrationsToRun'
+          initialMigrations    = drop l $ reverse migrations
           additionalMigrations = takeWhile
             (\mgr -> droppedEventually mgr && tableDoesNotExist mgr)
             initialMigrations
@@ -796,7 +807,9 @@ sqlGetTableID table = parenthesize . toSQLCommand $
 
 -- *** PRIMARY KEY ***
 
-sqlGetPrimaryKey :: (MonadDB m, MonadThrow m) => Table -> m (Maybe (PrimaryKey, RawSQL ()))
+sqlGetPrimaryKey
+  :: (MonadDB m, MonadThrow m)
+  => Table -> m (Maybe (PrimaryKey, RawSQL ()))
 sqlGetPrimaryKey table = do
 
   (mColumnNumbers :: Maybe [Int16]) <- do
@@ -833,7 +846,8 @@ sqlGetPrimaryKey table = do
         sqlWhereEq "c.contype" 'p'
         sqlWhereEqSql "c.conrelid" $ sqlGetTableID table
         sqlResult "c.conname::text"
-        sqlResult $ Data.String.fromString ("array['" <> (mintercalate "', '" columnNames) <> "']::text[]")
+        sqlResult $ Data.String.fromString
+          ("array['" <> (mintercalate "', '" columnNames) <> "']::text[]")
 
       join <$> fetchMaybe fetchPrimaryKey
 
@@ -846,7 +860,8 @@ fetchPrimaryKey (name, Array1 columns) = (, unsafeSQL name)
 sqlGetChecks :: Table -> SQL
 sqlGetChecks table = toSQLCommand . sqlSelect "pg_catalog.pg_constraint c" $ do
   sqlResult "c.conname::text"
-  sqlResult "regexp_replace(pg_get_constraintdef(c.oid, true), 'CHECK \\((.*)\\)', '\\1') AS body" -- check body
+  sqlResult "regexp_replace(pg_get_constraintdef(c.oid, true), \
+            \'CHECK \\((.*)\\)', '\\1') AS body" -- check body
   sqlWhereEq "c.contype" 'c'
   sqlWhereEqSql "c.conrelid" $ sqlGetTableID table
 
@@ -903,11 +918,16 @@ sqlGetForeignKeys table = toSQLCommand
   sqlResult $
     "ARRAY(SELECT a.attname::text FROM pg_catalog.pg_attribute a JOIN ("
     <> unnestWithOrdinality "r.conkey"
-    <> ") conkeys ON (a.attnum = conkeys.item) WHERE a.attrelid = r.conrelid ORDER BY conkeys.n)" -- constrained columns
+    <> ") conkeys ON (a.attnum = conkeys.item) \
+       \WHERE a.attrelid = r.conrelid \
+       \ORDER BY conkeys.n)" -- constrained columns
   sqlResult "c.relname::text" -- referenced table
-  sqlResult $ "ARRAY(SELECT a.attname::text FROM pg_catalog.pg_attribute a JOIN ("
+  sqlResult $ "ARRAY(SELECT a.attname::text \
+              \FROM pg_catalog.pg_attribute a JOIN ("
     <> unnestWithOrdinality "r.confkey"
-    <> ") confkeys ON (a.attnum = confkeys.item) WHERE a.attrelid = r.confrelid ORDER BY confkeys.n)" -- referenced columns
+    <> ") confkeys ON (a.attnum = confkeys.item) \
+       \WHERE a.attrelid = r.confrelid \
+       \ORDER BY confkeys.n)" -- referenced columns
   sqlResult "r.confupdtype" -- on update
   sqlResult "r.confdeltype" -- on delete
   sqlResult "r.condeferrable" -- deferrable?
@@ -942,4 +962,5 @@ fetchForeignKey
       'c' -> ForeignKeyCascade
       'n' -> ForeignKeySetNull
       'd' -> ForeignKeySetDefault
-      _   -> error $ "fetchForeignKey: invalid foreign key action code: " ++ show c
+      _   -> error $ "fetchForeignKey: invalid foreign key action code: "
+                     ++ show c

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Control
 
 import Data.Monoid
+import Prelude
 import Data.Int
 import qualified Data.Text as T
 import Data.Typeable

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -727,18 +727,18 @@ migrationTest2 connSource =
   assertNoException "checkDatabaseAllowUnknownTables runs fine \
                     \for consistent DB" $
     checkDatabaseAllowUnknownTables extrasOptions [] currentSchema
-  assertException "checkDatabase should throw exception for wrong scheme" $
+  assertException "checkDatabase should throw exception for wrong schema" $
     checkDatabase extrasOptions [] differentSchema
-  assertException ("checkDatabaseAllowUnknownTables "
-                   ++ "should throw exception for wrong scheme") $
+  assertException ("checkDatabaseAllowUnknownTables \
+                   \should throw exception for wrong scheme") $
     checkDatabaseAllowUnknownTables extrasOptions [] differentSchema
 
   runSQL_ "INSERT INTO table_versions (name, version) \
           \VALUES ('unknown_table', 0)"
   assertException "checkDatabase throw when extra entry in 'table_versions'" $
     checkDatabase extrasOptions [] currentSchema
-  assertNoException ("checkDatabaseAllowUnknownTables "
-                     ++ "accepts extra entry in 'table_versions'") $
+  assertNoException ("checkDatabaseAllowUnknownTables \
+                     \accepts extra entry in 'table_versions'") $
     checkDatabaseAllowUnknownTables extrasOptions [] currentSchema
   runSQL_ "DELETE FROM table_versions where name='unknown_table'"
 
@@ -752,8 +752,8 @@ migrationTest2 connSource =
           \VALUES ('unknown_table', 0)"
   assertException "checkDatabase should throw with unknown table" $
     checkDatabase extrasOptions [] currentSchema
-  assertNoException ("checkDatabaseAllowUnknownTables "
-                     ++ "accepts unknown tables with version") $
+  assertNoException ("checkDatabaseAllowUnknownTables \
+                     \accepts unknown tables with version") $
     checkDatabaseAllowUnknownTables extrasOptions [] currentSchema
 
   freshTestDB    step
@@ -793,8 +793,8 @@ migrationTest3 connSource =
   migrateDBToSchema2  step
   testDBSchema2       step badGuyIds robberyIds
 
-  assertException ( "Trying to run the same migration twice should fail, "
-                    ++ "when starting with a createTable migration" ) $
+  assertException ( "Trying to run the same migration twice should fail, \
+                     \when starting with a createTable migration" ) $
     migrateDBToSchema2Hacky  step
 
   freshTestDB         step

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -412,12 +412,12 @@ schema6Tables =
 schema6Migrations :: (MonadDB m) => Migration m
 schema6Migrations =
     Migration
-    {
-      mgrTableName = tblName tableParticipatedInRobberySchema1
+    { mgrTableName = tblName tableParticipatedInRobberySchema1
     , mgrFrom = tblVersion tableParticipatedInRobberySchema1
-    , mgrAction = StandardMigration $ do
-                    runQuery_ $ ("ALTER TABLE participated_in_robbery DROP CONSTRAINT " <>
-                                 "pk__participated_in_robbery" :: RawSQL ())
+    , mgrAction =
+      StandardMigration $ do
+        runQuery_ $ ("ALTER TABLE participated_in_robbery DROP CONSTRAINT \
+                     \pk__participated_in_robbery" :: RawSQL ())
     }
 
 
@@ -529,7 +529,8 @@ migrateDBToSchema2Hacky step = do
   let extrasOptions = def
       extensions    = []
       domains       = []
-  step "Hackily migrating the database (schema version 1 -> schema version 2)..."
+  step "Hackily migrating the database (schema version 1 \
+       \-> schema version 2)..."
   migrateDatabase extrasOptions extensions domains
     schema2Tables schema2Migrations'
   checkDatabase extrasOptions domains schema2Tables
@@ -722,7 +723,8 @@ migrationTest2 connSource =
       extrasOptions = def { eoEnforcePKs = True }
   assertNoException "checkDatabase should run fine for consistent DB" $
     checkDatabase extrasOptions [] currentSchema
-  assertNoException "checkDatabaseAllowUnknownTables runs fine for consistent DB" $
+  assertNoException "checkDatabaseAllowUnknownTables runs fine \
+                    \for consistent DB" $
     checkDatabaseAllowUnknownTables extrasOptions [] currentSchema
   assertException "checkDatabase should throw exception for wrong scheme" $
     checkDatabase extrasOptions [] differentSchema
@@ -730,7 +732,8 @@ migrationTest2 connSource =
                    ++ "should throw exception for wrong scheme") $
     checkDatabaseAllowUnknownTables extrasOptions [] differentSchema
 
-  runSQL_ "INSERT INTO table_versions (name, version) VALUES ('unknown_table', 0)"
+  runSQL_ "INSERT INTO table_versions (name, version) \
+          \VALUES ('unknown_table', 0)"
   assertException "checkDatabase throw when extra entry in 'table_versions'" $
     checkDatabase extrasOptions [] currentSchema
   assertNoException ("checkDatabaseAllowUnknownTables "
@@ -744,7 +747,8 @@ migrationTest2 connSource =
   assertNoException "checkDatabaseAllowUnknownTables accepts unknown table" $
     checkDatabaseAllowUnknownTables extrasOptions [] currentSchema
 
-  runSQL_ "INSERT INTO table_versions (name, version) VALUES ('unknown_table', 0)"
+  runSQL_ "INSERT INTO table_versions (name, version) \
+          \VALUES ('unknown_table', 0)"
   assertException "checkDatabase should throw with unknown table" $
     checkDatabase extrasOptions [] currentSchema
   assertNoException ("checkDatabaseAllowUnknownTables "
@@ -761,14 +765,17 @@ migrationTest2 connSource =
 
   step "Recreating the database (schema version 1, one table is missing PK)..."
 
-  migrateDatabase optionsNoPKCheck [] [] schema1TablesWithMissingPK [schema1MigrationsWithMissingPK]
+  migrateDatabase optionsNoPKCheck [] []
+    schema1TablesWithMissingPK [schema1MigrationsWithMissingPK]
   checkDatabase optionsNoPKCheck [] withMissingPKSchema
 
-  assertException ("checkDatabase should throw when PK missing from table " <>
-                   "'participated_in_robbery' and check is enabled") $
+  assertException
+    "checkDatabase should throw when PK missing from table \
+    \'participated_in_robbery' and check is enabled" $
     checkDatabase optionsWithPKCheck [] withMissingPKSchema
-  assertNoException ("checkDatabase should not throw when PK missing from table " <>
-                     "'participated_in_robbery' and check is disabled") $
+  assertNoException
+    "checkDatabase should not throw when PK missing from table \
+    \'participated_in_robbery' and check is disabled" $
     checkDatabase optionsNoPKCheck [] withMissingPKSchema
 
   freshTestDB step


### PR DESCRIPTION
Same as #18, but for the `1.6` branch.