### PR TITLE
Implement UUID Column Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# hpqtypes-extras-1.10.0.0 (2019-11-05)
+* Implement `UuidT` Column Type ([#28](https://github.com/scrive/hpqtypes-extras/pull/28)).
+
 # hpqtypes-extras-1.9.0.1 (2019-06-04)
 * Create composite types automatically only if database is empty.
 

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -58,7 +58,7 @@ library
                , cryptohash        >= 0.11    && < 0.12
                , exceptions        >= 0.10    && < 0.11
                , mtl               >= 2.2     && < 2.3
-               , fields-json       >= 0.2     && < 0.3
+               , fields-json       >= 0.4     && < 0.5
                , text              >= 1.2     && < 1.3
                , lifted-base       >= 0.2     && < 0.3
                , monad-control     >= 1.0     && < 1.1
@@ -66,7 +66,6 @@ library
                , text-show         >= 3.7     && < 3.9
                , log-base          >= 0.7     && < 0.9
                , safe              >= 0.3     && < 0.4
-               , uuid              >= 1.3     && < 1.4
 
   default-language: Haskell2010
   default-extensions: BangPatterns
@@ -111,4 +110,4 @@ test-suite  hpqtypes-extras-tests
                       tasty-hunit,
                       text,
                       transformers,
-                      uuid
+                      uuid-types

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.18
 name:                hpqtypes-extras
-version:             1.9.0.1
+version:             1.10.0.0
 synopsis:            Extra utilities for hpqtypes library
 description:         The following extras for hpqtypes library:
                      .
@@ -51,7 +51,7 @@ library
                  , Database.PostgreSQL.PQTypes.Utils.NubList
 
   build-depends: base              >= 4.9     && < 4.13
-               , hpqtypes          >= 1.7.0.0 && < 1.8.0.0
+               , hpqtypes          >= 1.8.0.0 && < 1.9.0.0
                , base16-bytestring >= 0.1     && < 0.2
                , bytestring        >= 0.10    && < 0.11
                , containers        >= 0.5     && < 0.7
@@ -66,6 +66,7 @@ library
                , text-show         >= 3.7     && < 3.9
                , log-base          >= 0.7     && < 0.9
                , safe              >= 0.3     && < 0.4
+               , uuid              >= 1.3     && < 1.4
 
   default-language: Haskell2010
   default-extensions: BangPatterns
@@ -109,4 +110,5 @@ test-suite  hpqtypes-extras-tests
                       tasty,
                       tasty-hunit,
                       text,
-                      transformers
+                      transformers,
+                      uuid

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -18,6 +18,7 @@ data ColumnType
   | DateT
   | DoubleT
   | IntegerT
+  | UuidT
   | IntervalT
   | JsonT
   | JsonbT
@@ -44,6 +45,7 @@ instance FromSQL ColumnType where
         "date" -> DateT
         "double precision" -> DoubleT
         "integer" -> IntegerT
+        "uuid" -> UuidT
         "interval" -> IntervalT
         "json" -> JsonT
         "jsonb" -> JsonbT
@@ -64,6 +66,7 @@ columnTypeToSQL BoolT              = "BOOLEAN"
 columnTypeToSQL DateT              = "DATE"
 columnTypeToSQL DoubleT            = "DOUBLE PRECISION"
 columnTypeToSQL IntegerT           = "INTEGER"
+columnTypeToSQL UuidT              = "UUID"
 columnTypeToSQL IntervalT          = "INTERVAL"
 columnTypeToSQL JsonT              = "JSON"
 columnTypeToSQL JsonbT             = "JSONB"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,7 +9,7 @@ import Data.Monoid
 import Prelude
 import qualified Data.Text as T
 import Data.Typeable
-import Data.UUID
+import Data.UUID.Types
 
 import Database.PostgreSQL.PQTypes
 import Database.PostgreSQL.PQTypes.Checks


### PR DESCRIPTION
This PR adds a new `UuidT` column type which makes use of the UUID format implemented in https://github.com/scrive/hpqtypes/pull/17. 

It also modifies the existing test to make use of the UUID type instead of regular integer. The alternative is to have a mix of INT and UUID when testing some of the tables. Otherwise I can write separate tests just for UUID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/hpqtypes-extras/28)
<!-- Reviewable:end -->
