### PR TITLE
Updating base16 bytestring version

### DIFF
--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -52,7 +52,7 @@ library
 
   build-depends: base              >= 4.9     && < 5
                , hpqtypes          >= 1.8.0.0 && < 2.0.0.0
-               , base16-bytestring >= 0.1     && < 0.2
+               , base16-bytestring >= 0.1     && < 1.0.1.0
                , bytestring        >= 0.10    && < 0.11
                , containers        >= 0.5     && < 0.7
                , cryptohash        >= 0.11    && < 0.12


### PR DESCRIPTION
WIdening the depedency version for `byte16-bytestring` to all available in the hackage (does no harm it seems)