### PR TITLE
Add DerivingVia helpers for enums

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -180,7 +180,7 @@ jobs:
       - name: doctest
         run: |
           cd ${PKGDIR_hpqtypes_extras} || false
-          doctest  -XBangPatterns -XDeriveDataTypeable -XExistentialQuantification -XFlexibleContexts -XGeneralizedNewtypeDeriving -XLambdaCase -XMultiWayIf -XOverloadedStrings -XRankNTypes -XRecordWildCards -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeFamilies -XUndecidableInstances -XViewPatterns src
+          doctest  -XBangPatterns -XDeriveDataTypeable -XExistentialQuantification -XFlexibleContexts -XGeneralizedNewtypeDeriving -XLambdaCase -XMultiWayIf -XOverloadedStrings -XRankNTypes -XRecordWildCards -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeApplications -XTypeFamilies -XUndecidableInstances -XViewPatterns src
       - name: cabal check
         run: |
           cd ${PKGDIR_hpqtypes_extras} || false

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -28,12 +28,12 @@ data T = T01 | T02 | T03 | T04 | T05 | T06 | T07 | T08 | T09 | T10
 instance NFData T where
   rnf = (`seq` ())
 
--- | SQL encoding for 'T'.
+-- | Enum encoding for 'T'.
 --
 -- >>> isInjective (encodeEnum @T)
 -- True
-instance SQLEnumEncoding T where
-   type SQLEnumType T = Int16
+instance EnumEncoding T where
+   type EnumBase T = Int16
    encodeEnum = \case
      T01 -> 1;  T02 -> 2;  T03 -> 3;  T04 -> 4;  T05 -> 5
      T06 -> 6;  T07 -> 7;  T08 -> 8;  T09 -> 9;  T10 -> 10
@@ -58,11 +58,11 @@ data S = S01 | S02 | S03 | S04 | S05 | S06 | S07 | S08 | S09 | S10
 instance NFData S where
   rnf = (`seq` ())
 
--- | SQL encoding for 'S'.
+-- | Enum encoding for 'S'.
 --
 -- >>> isInjective (encodeEnumAsText @S)
 -- True
-instance SQLEnumAsTextEncoding S where
+instance EnumAsTextEncoding S where
   encodeEnumAsText = \case
     S01 -> "text_01"; S02 -> "text_02"; S03 -> "text_03"; S04 -> "text_04"
     S05 -> "text_05"; S06 -> "text_06"; S07 -> "text_07"; S08 -> "text_08"

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,0 +1,79 @@
+module Main where
+
+import Control.DeepSeq
+import Data.Int
+import Test.Tasty.Bench
+
+import Database.PostgreSQL.PQTypes.Deriving
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "enum"
+    [ bench "encode" $ nf (encodeEnum @T) T42
+    , bench "decode" $ nf (decodeEnum @T) 42
+    ]
+  , bgroup "enum-text"
+    [ bench "encode" $ nf (encodeEnumAsText @S) S42
+    , bench "decode" $ nf (decodeEnumAsText @S) "text_42"
+    ]
+  ]
+
+data T = T01 | T02 | T03 | T04 | T05 | T06 | T07 | T08 | T09 | T10
+       | T11 | T12 | T13 | T14 | T15 | T16 | T17 | T18 | T19 | T20
+       | T21 | T22 | T23 | T24 | T25 | T26 | T27 | T28 | T29 | T30
+       | T31 | T32 | T33 | T34 | T35 | T36 | T37 | T38 | T39 | T40
+       | T41 | T42 | T43 | T44 | T45 | T46 | T47 | T48 | T49 | T50
+  deriving (Eq, Show, Enum, Bounded)
+
+instance NFData T where
+  rnf = (`seq` ())
+
+-- | SQL encoding for 'T'.
+--
+-- >>> isInjective (encodeEnum @T)
+-- True
+instance SQLEnumEncoding T where
+   type SQLEnumType T = Int16
+   encodeEnum = \case
+     T01 -> 1;  T02 -> 2;  T03 -> 3;  T04 -> 4;  T05 -> 5
+     T06 -> 6;  T07 -> 7;  T08 -> 8;  T09 -> 9;  T10 -> 10
+     T11 -> 11; T12 -> 12; T13 -> 13; T14 -> 14; T15 -> 15
+     T16 -> 16; T17 -> 17; T18 -> 18; T19 -> 19; T20 -> 20
+     T21 -> 21; T22 -> 22; T23 -> 23; T24 -> 24; T25 -> 25
+     T26 -> 26; T27 -> 27; T28 -> 28; T29 -> 29; T30 -> 30
+     T31 -> 31; T32 -> 32; T33 -> 33; T34 -> 34; T35 -> 35
+     T36 -> 36; T37 -> 37; T38 -> 38; T39 -> 39; T40 -> 40
+     T41 -> 41; T42 -> 42; T43 -> 43; T44 -> 44; T45 -> 45
+     T46 -> 46; T47 -> 47; T48 -> 48; T49 -> 49; T50 -> 50
+
+----------------------------------------
+
+data S = S01 | S02 | S03 | S04 | S05 | S06 | S07 | S08 | S09 | S10
+       | S11 | S12 | S13 | S14 | S15 | S16 | S17 | S18 | S19 | S20
+       | S21 | S22 | S23 | S24 | S25 | S26 | S27 | S28 | S29 | S30
+       | S31 | S32 | S33 | S34 | S35 | S36 | S37 | S38 | S39 | S40
+       | S41 | S42 | S43 | S44 | S45 | S46 | S47 | S48 | S49 | S50
+  deriving (Eq, Show, Enum, Bounded)
+
+instance NFData S where
+  rnf = (`seq` ())
+
+-- | SQL encoding for 'S'.
+--
+-- >>> isInjective (encodeEnumAsText @S)
+-- True
+instance SQLEnumAsTextEncoding S where
+  encodeEnumAsText = \case
+    S01 -> "text_01"; S02 -> "text_02"; S03 -> "text_03"; S04 -> "text_04"
+    S05 -> "text_05"; S06 -> "text_06"; S07 -> "text_07"; S08 -> "text_08"
+    S09 -> "text_09"; S10 -> "text_10"; S11 -> "text_11"; S12 -> "text_12"
+    S13 -> "text_13"; S14 -> "text_14"; S15 -> "text_15"; S16 -> "text_16"
+    S17 -> "text_17"; S18 -> "text_18"; S19 -> "text_19"; S20 -> "text_20"
+    S21 -> "text_21"; S22 -> "text_22"; S23 -> "text_23"; S24 -> "text_24"
+    S25 -> "text_25"; S26 -> "text_26"; S27 -> "text_27"; S28 -> "text_28"
+    S29 -> "text_29"; S30 -> "text_30"; S31 -> "text_31"; S32 -> "text_32"
+    S33 -> "text_33"; S34 -> "text_34"; S35 -> "text_35"; S36 -> "text_36"
+    S37 -> "text_37"; S38 -> "text_38"; S39 -> "text_39"; S40 -> "text_40"
+    S41 -> "text_41"; S42 -> "text_42"; S43 -> "text_43"; S44 -> "text_44"
+    S45 -> "text_45"; S46 -> "text_46"; S47 -> "text_47"; S48 -> "text_48"
+    S49 -> "text_49"; S50 -> "text_50";

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,4 +1,5 @@
 branches:       master
+benchmarks:     True
 doctest:        True
 tests:          True
 postgresql:     True

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -32,7 +32,7 @@ library
   ghc-options: -Wall
 
   exposed-modules: Database.PostgreSQL.PQTypes.Checks
-                 , Database.PostgreSQL.PQTypes.DerivingVia
+                 , Database.PostgreSQL.PQTypes.Deriving
                  , Database.PostgreSQL.PQTypes.ExtrasOptions
                  , Database.PostgreSQL.PQTypes.Migrate
                  , Database.PostgreSQL.PQTypes.Model

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -1,4 +1,4 @@
-cabal-version:       1.18
+cabal-version:       2.2
 name:                hpqtypes-extras
 version:             1.10.3.0
 synopsis:            Extra utilities for hpqtypes library
@@ -10,7 +10,7 @@ description:         The following extras for hpqtypes library:
                        of a database schema.
 
 homepage:            https://github.com/scrive/hpqtypes-extras
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 extra-source-files:  CHANGELOG.md, README.md
 author:              Scrive AB
@@ -26,7 +26,28 @@ Source-repository head
   Type:     git
   Location: https://github.com/scrive/hpqtypes-extras.git
 
+common common-stanza
+  Default-Language: Haskell2010
+  Default-Extensions: BangPatterns
+                    , DeriveDataTypeable
+                    , ExistentialQuantification
+                    , FlexibleContexts
+                    , GeneralizedNewtypeDeriving
+                    , LambdaCase
+                    , MultiWayIf
+                    , OverloadedStrings
+                    , RankNTypes
+                    , RecordWildCards
+                    , ScopedTypeVariables
+                    , StandaloneDeriving
+                    , TupleSections
+                    , TypeApplications
+                    , TypeFamilies
+                    , UndecidableInstances
+                    , ViewPatterns
+
 library
+  Import: common-stanza
   hs-source-dirs: src
 
   ghc-options: -Wall
@@ -70,26 +91,11 @@ library
                , safe              >= 0.3     && < 0.4
 
   default-language: Haskell2010
-  default-extensions: BangPatterns
-                    , DeriveDataTypeable
-                    , ExistentialQuantification
-                    , FlexibleContexts
-                    , GeneralizedNewtypeDeriving
-                    , LambdaCase
-                    , MultiWayIf
-                    , OverloadedStrings
-                    , RankNTypes
-                    , RecordWildCards
-                    , ScopedTypeVariables
-                    , StandaloneDeriving
-                    , TupleSections
-                    , TypeApplications
-                    , TypeFamilies
-                    , UndecidableInstances
-                    , ViewPatterns
+  default-extensions:
   other-extensions:   CPP
 
 test-suite  hpqtypes-extras-tests
+  Import:             common-stanza
   type:               exitcode-stdio-1.0
   hs-source-dirs:     test
   main-is:            Main.hs
@@ -115,3 +121,15 @@ test-suite  hpqtypes-extras-tests
                       time,
                       transformers,
                       uuid-types
+
+benchmark bench
+  Import:             common-stanza
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     benchmark
+  main-is:            Main.hs
+
+  ghc-options:        -Wall
+  build-depends:      base
+                    , deepseq
+                    , hpqtypes-extras
+                    , tasty-bench

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -32,6 +32,7 @@ library
   ghc-options: -Wall
 
   exposed-modules: Database.PostgreSQL.PQTypes.Checks
+                 , Database.PostgreSQL.PQTypes.DerivingVia
                  , Database.PostgreSQL.PQTypes.ExtrasOptions
                  , Database.PostgreSQL.PQTypes.Migrate
                  , Database.PostgreSQL.PQTypes.Model
@@ -57,6 +58,7 @@ library
                , containers        >= 0.5     && < 0.7
                , cryptohash        >= 0.11    && < 0.12
                , exceptions        >= 0.10    && < 0.11
+               , extra             >= 1.6.17  && < 1.8.0
                , mtl               >= 2.2     && < 2.3
                , fields-json       >= 0.4     && < 0.5
                , text              >= 1.2     && < 1.3

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -66,7 +66,6 @@ library
                , monad-control     >= 1.0     && < 1.1
                , semigroups        >= 0.16    && < 0.20
                , text-show         >= 3.7     && < 3.9
-               , time
                , log-base          >= 0.7     && < 0.10
                , safe              >= 0.3     && < 0.4
 
@@ -84,11 +83,11 @@ library
                     , ScopedTypeVariables
                     , StandaloneDeriving
                     , TupleSections
+                    , TypeApplications
                     , TypeFamilies
                     , UndecidableInstances
                     , ViewPatterns
   other-extensions:   CPP
-                    , TypeApplications
 
 test-suite  hpqtypes-extras-tests
   type:               exitcode-stdio-1.0
@@ -103,6 +102,7 @@ test-suite  hpqtypes-extras-tests
                     , ScopedTypeVariables
   ghc-options:        -Wall
   build-depends:      base,
+                      QuickCheck,
                       exceptions,
                       hpqtypes,
                       hpqtypes-extras,
@@ -112,5 +112,6 @@ test-suite  hpqtypes-extras-tests
                       tasty,
                       tasty-hunit,
                       text,
+                      time,
                       transformers,
                       uuid-types

--- a/src/Database/PostgreSQL/PQTypes/Deriving.hs
+++ b/src/Database/PostgreSQL/PQTypes/Deriving.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes, TypeApplications #-}
 module Database.PostgreSQL.PQTypes.Deriving (
-  -- * Helpers, to be used with `deriving via`.
+  -- * Helpers, to be used with @deriving via@ (@-XDerivingVia@).
     SQLEnum(..)
   , SQLEnumEncoding(..)
   , SQLEnumAsText(..)
   , SQLEnumAsTextEncoding(..)
-    -- * For use in doctests:
+    -- * For use in doctests.
   , isInjective
   ) where
 
@@ -17,9 +17,9 @@ import Data.Typeable
 import Database.PostgreSQL.PQTypes
 import qualified Data.Map.Strict as Map
 
-
--- | Helper newtype to be used with `deriving via` to derive `(PQFormat, ToSQL,
--- FromSQL)` instances for enums, given an instance of `SQLEnumEncoding`.
+-- | Helper newtype to be used with @deriving via@ to derive @(PQFormat, ToSQL,
+-- FromSQL)@ instances for enums, given an instance of 'SQLEnumEncoding'. Hint:
+-- non-trivial 'Enum' instances can be derived using the 'generic-data' package!
 --
 -- Example use:
 -- >>> :{
@@ -37,7 +37,7 @@ import qualified Data.Map.Strict as Map
 --     Red -> 1337
 --     Mauve -> -1
 --
--- isInjective (encodeEnum :: Colours -> Int16)
+-- isInjective (encodeEnum @Colours)
 -- :}
 -- True
 newtype SQLEnum a = SQLEnum a
@@ -59,8 +59,8 @@ class
   type SQLEnumType a
   encodeEnum :: a -> SQLEnumType a
 
-  -- | We include the definition of the inverse map as part of `SQLEnumEncoding`
-  -- to ensure it is only computed once.
+  -- | We include the definition of the inverse map as part of the
+  -- 'SQLEnumEncoding' instance to ensure it is only computed once.
   decodeEnumMap :: Map (SQLEnumType a) a
   decodeEnumMap = Map.fromList [ (encodeEnum a, a) | a <- enumerate ]
 
@@ -83,8 +83,9 @@ instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
       Just a -> return $ SQLEnum a
 
 
--- | A special case of `SQLEnum`, where the enum is to be encoded as text (and
--- SQLEnum can't be used because of the `Enum` constraint).
+-- | A special case of 'SQLEnum', where the enum is to be encoded as text
+-- ('SQLEnum' can't be used because of the 'Enum' constraint on the domain of
+-- 'encodeEnum').
 --
 -- Example use:
 -- >>> :{
@@ -98,7 +99,7 @@ instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
 --     Bertrand -> "bertrand"
 --     Charles -> "charles"
 --
--- isInjective (encodeEnumAsText :: Person -> Text)
+-- isInjective (encodeEnumAsText @Person)
 -- :}
 -- True
 newtype SQLEnumAsText a = SQLEnumAsText a
@@ -106,8 +107,8 @@ newtype SQLEnumAsText a = SQLEnumAsText a
 class (Enum a , Bounded a) => SQLEnumAsTextEncoding a where
   encodeEnumAsText :: a -> Text
 
-  -- | We include the inverse map as part of `SQLEnumTextEncoding` to ensure it
-  -- is only computed once.
+  -- | We include the inverse map as part of the 'SQLEnumTextEncoding' instance
+  -- to ensure it is only computed once.
   decodeEnumAsTextMap :: Map Text a
   decodeEnumAsTextMap = Map.fromList [ (encodeEnumAsText a, a) | a <- enumerate ]
 

--- a/src/Database/PostgreSQL/PQTypes/Deriving.hs
+++ b/src/Database/PostgreSQL/PQTypes/Deriving.hs
@@ -2,9 +2,9 @@
 module Database.PostgreSQL.PQTypes.Deriving (
   -- * Helpers, to be used with @deriving via@ (@-XDerivingVia@).
     SQLEnum(..)
-  , SQLEnumEncoding(..)
+  , EnumEncoding(..)
   , SQLEnumAsText(..)
-  , SQLEnumAsTextEncoding(..)
+  , EnumAsTextEncoding(..)
     -- * For use in doctests.
   , isInjective
   ) where
@@ -18,21 +18,22 @@ import Database.PostgreSQL.PQTypes
 import qualified Data.Map.Strict as Map
 
 -- | Helper newtype to be used with @deriving via@ to derive @(PQFormat, ToSQL,
--- FromSQL)@ instances for enums, given an instance of 'SQLEnumEncoding'.
+-- FromSQL)@ instances for enums, given an instance of 'EnumEncoding'.
 --
 -- /Hint:/ non-trivial 'Enum' instances can be derived using the 'generic-data'
 -- package!
 --
 -- >>> :{
--- data Colours = Blue | Black | Red | Mauve
+-- data Colours = Blue | Black | Red | Mauve | Orange
 --   deriving (Eq, Show, Enum, Bounded)
--- instance SQLEnumEncoding Colours where
---   type SQLEnumType Colours = Int16
+-- instance EnumEncoding Colours where
+--   type EnumBase Colours = Int16
 --   encodeEnum = \case
---     Blue  -> 1
---     Black -> 7
---     Red   -> 2
---     Mauve -> 6
+--     Blue   -> 1
+--     Black  -> 7
+--     Red    -> 2
+--     Mauve  -> 6
+--     Orange -> 3
 -- :}
 --
 -- /Note:/ To get SQL-specific instances use @DerivingVia@:
@@ -50,50 +51,54 @@ import qualified Data.Map.Strict as Map
 -- Right Black
 --
 -- >>> decodeEnum @Colours 42
--- Left [(1,2),(6,7)]
+-- Left [(1,3),(6,7)]
 newtype SQLEnum a = SQLEnum a
 
 class
-  ( -- The semantic type needs to be finitely enumerable,
+  ( -- The semantic type needs to be finitely enumerable.
     Enum a
   , Bounded a
-  -- and the target type has to be an enum with an SQL representation.
-  , FromSQL (SQLEnumType a)
-  , ToSQL (SQLEnumType a)
-  , PQFormat (SQLEnumType a)
-  -- Miscellaneous constraints:
-  , Enum (SQLEnumType a)
-  , Ord (SQLEnumType a)
-  , Show (SQLEnumType a)
-  , Typeable (SQLEnumType a)
-  ) => SQLEnumEncoding a where
-  type SQLEnumType a
-  -- | Encode @a@ as an SQL compatible type.
-  encodeEnum :: a -> SQLEnumType a
+    -- The base type needs to be enumerable and ordered.
+  , Enum (EnumBase a)
+  , Ord (EnumBase a)
+  ) => EnumEncoding a where
+  type EnumBase a
+  -- | Encode @a@ as a base type.
+  encodeEnum :: a -> EnumBase a
 
-  -- | Decode SQL compatible type to an @a@. If the conversion fails, a list of
-  -- valid ranges is returned instead.
+  -- | Decode base type to an @a@. If the conversion fails, a list of valid
+  -- ranges is returned instead.
   --
-  -- /Note:/ The default implementation looks up the value in 'decodeEnumMap'
-  -- and can be overwritten for performance if necessary.
-  decodeEnum :: SQLEnumType a -> Either [(SQLEnumType a, SQLEnumType a)] a
+  -- /Note:/ The default implementation looks up values in 'decodeEnumMap' and
+  -- can be overwritten for performance if necessary.
+  decodeEnum :: EnumBase a -> Either [(EnumBase a, EnumBase a)] a
   decodeEnum b = maybe (Left . intervals $ Map.keys (decodeEnumMap @a)) Right
                $ Map.lookup b (decodeEnumMap @a)
 
-  -- | We include the definition of the inverse map as part of the
-  -- 'SQLEnumEncoding' instance to ensure it is only computed once.
-  decodeEnumMap :: Map (SQLEnumType a) a
+  -- | Include the inverse map as a top-level part of the 'EnumEncoding'
+  -- instance to ensure it is only computed once by GHC.
+  decodeEnumMap :: Map (EnumBase a) a
   decodeEnumMap = Map.fromList [ (encodeEnum a, a) | a <- enumerate ]
 
-instance SQLEnumEncoding a => PQFormat (SQLEnum a) where
-  pqFormat = pqFormat @(SQLEnumType a)
+instance PQFormat (EnumBase a) => PQFormat (SQLEnum a) where
+  pqFormat = pqFormat @(EnumBase a)
 
-instance SQLEnumEncoding a => ToSQL (SQLEnum a) where
-  type PQDest (SQLEnum a) = PQDest (SQLEnumType a)
+instance
+  ( EnumEncoding a
+  , PQFormat (EnumBase a)
+  , ToSQL (EnumBase a)
+  ) => ToSQL (SQLEnum a) where
+  type PQDest (SQLEnum a) = PQDest (EnumBase a)
   toSQL (SQLEnum a) = toSQL $ encodeEnum a
 
-instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
-  type PQBase (SQLEnum a) = PQBase (SQLEnumType a)
+instance
+  ( EnumEncoding a
+  , PQFormat (EnumBase a)
+  , FromSQL (EnumBase a)
+  , Show (EnumBase a)
+  , Typeable (EnumBase a)
+  ) => FromSQL (SQLEnum a) where
+  type PQBase (SQLEnum a) = PQBase (EnumBase a)
   fromSQL base = do
     b <- fromSQL base
     case decodeEnum b of
@@ -110,11 +115,11 @@ instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
 -- >>> :{
 -- data Person = Alfred | Bertrand | Charles
 --   deriving (Eq, Show, Enum, Bounded)
--- instance SQLEnumAsTextEncoding Person where
+-- instance EnumAsTextEncoding Person where
 --   encodeEnumAsText = \case
---     Alfred -> "alfred"
+--     Alfred   -> "alfred"
 --     Bertrand -> "bertrand"
---     Charles -> "charles"
+--     Charles  -> "charles"
 -- :}
 --
 -- /Note:/ To get SQL-specific instances use @DerivingVia@:
@@ -135,32 +140,32 @@ instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
 -- Left ["alfred","bertrand","charles"]
 newtype SQLEnumAsText a = SQLEnumAsText a
 
-class (Enum a , Bounded a) => SQLEnumAsTextEncoding a where
+class (Enum a, Bounded a) => EnumAsTextEncoding a where
   -- | Encode @a@ as 'Text'.
   encodeEnumAsText :: a -> Text
 
   -- | Decode 'Text' to an @a@. If the conversion fails, a list of valid values
   -- is returned instead.
   --
-  -- /Note:/ The default implementation looks up the value in
-  -- 'decodeEnumAsTextMap' and can be overwritten for performance if necessary.
+  -- /Note:/ The default implementation looks up values in 'decodeEnumAsTextMap'
+  -- and can be overwritten for performance if necessary.
   decodeEnumAsText :: Text -> Either [Text] a
   decodeEnumAsText text = maybe (Left $ Map.keys (decodeEnumAsTextMap @a)) Right
                         $ Map.lookup text (decodeEnumAsTextMap @a)
 
-  -- | We include the inverse map as part of the 'SQLEnumTextEncoding' instance
-  -- to ensure it is only computed once.
+  -- | Include the inverse map as a top-level part of the 'SQLEnumTextEncoding'
+  -- instance to ensure it is only computed once by GHC.
   decodeEnumAsTextMap :: Map Text a
   decodeEnumAsTextMap = Map.fromList [ (encodeEnumAsText a, a) | a <- enumerate ]
 
-instance SQLEnumAsTextEncoding a => PQFormat (SQLEnumAsText a) where
+instance EnumAsTextEncoding a => PQFormat (SQLEnumAsText a) where
   pqFormat = pqFormat @Text
 
-instance SQLEnumAsTextEncoding a => ToSQL (SQLEnumAsText a) where
+instance EnumAsTextEncoding a => ToSQL (SQLEnumAsText a) where
   type PQDest (SQLEnumAsText a) = PQDest Text
   toSQL (SQLEnumAsText a) = toSQL $ encodeEnumAsText a
 
-instance SQLEnumAsTextEncoding a => FromSQL (SQLEnumAsText a) where
+instance EnumAsTextEncoding a => FromSQL (SQLEnumAsText a) where
   type PQBase (SQLEnumAsText a) = PQBase Text
   fromSQL base = do
     text <- fromSQL base

--- a/src/Database/PostgreSQL/PQTypes/Deriving.hs
+++ b/src/Database/PostgreSQL/PQTypes/Deriving.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes, TypeApplications #-}
-module Database.PostgreSQL.PQTypes.DerivingVia (
+module Database.PostgreSQL.PQTypes.Deriving (
   -- * Helpers, to be used with `deriving via`.
     SQLEnum(..)
   , SQLEnumEncoding(..)
@@ -23,6 +23,8 @@ import qualified Data.Map.Strict as Map
 --
 -- Example use:
 -- >>> :{
+-- import Data.Int
+--
 -- data Colours = Blue | Black | Red | Mauve
 --   deriving (Enum, Bounded)
 --   deriving (PQFormat, ToSQL, FromSQL) via SQLEnum Colours
@@ -34,7 +36,10 @@ import qualified Data.Map.Strict as Map
 --     Black -> 42
 --     Red -> 1337
 --     Mauve -> -1
+--
+-- isInjective (encodeEnum :: Colours -> Int16)
 -- :}
+-- True
 newtype SQLEnum a = SQLEnum a
 
 class
@@ -92,7 +97,10 @@ instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
 --     Alfred -> "alfred"
 --     Bertrand -> "bertrand"
 --     Charles -> "charles"
+--
+-- isInjective (encodeEnumAsText :: Person -> Text)
 -- :}
+-- True
 newtype SQLEnumAsText a = SQLEnumAsText a
 
 class (Enum a , Bounded a) => SQLEnumAsTextEncoding a where

--- a/src/Database/PostgreSQL/PQTypes/DerivingVia.hs
+++ b/src/Database/PostgreSQL/PQTypes/DerivingVia.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE AllowAmbiguousTypes, TypeApplications #-}
+module Database.PostgreSQL.PQTypes.DerivingVia (
+  -- | Helpers, to be used with `deriving via`.
+    SQLEnum(..)
+  , SQLEnumEncoding(..)
+  , SQLEnumAsText(..)
+  , SQLEnumAsTextEncoding(..)
+  , isInjective  -- ^ for doctests
+  ) where
+
+import Control.Exception (SomeException(..), throwIO)
+import Data.List.Extra (enumerate, nubSort)
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+import Data.Typeable
+import Database.PostgreSQL.PQTypes
+import qualified Data.Map.Strict as Map
+
+-- | To be used in doctests to prove injectivity of encoding functions.
+--
+-- >>> isInjective (id :: Bool -> Bool)
+-- True
+--
+-- >>> isInjective (\(_ :: Bool) -> False)
+-- False
+isInjective :: (Enum a, Bounded a, Eq a, Eq b) => (a -> b) -> Bool
+isInjective f = null [ (a, b) | a <- enumerate, b <- enumerate, a /= b, f a == f b ]
+
+-- | Internal helper; given a list of values, decompose it into a list of
+-- intervals.
+-- >>> intervals [42,2,1,0,3,88,-1,43,42]
+-- [(-1,3),(42,43),(88,88)]
+--
+-- prop> nubSort xs == concatMap (\(l,r) -> [l .. r]) (intervals xs)
+intervals :: forall  a . (Enum a, Ord a) => [a] -> [(a, a)]
+intervals as = case nubSort as of
+  [] -> []
+  (first : ascendingRest) -> accumIntervals (first, first) ascendingRest
+  where
+    accumIntervals :: (a, a) -> [a] -> [(a, a)]
+    accumIntervals (lower, upper) [] = [(lower, upper)]
+    accumIntervals (lower, upper) (first' : ascendingRest') = if succ upper == first'
+      then accumIntervals (lower, first') ascendingRest'
+      else (lower, upper) : accumIntervals (first', first') ascendingRest'
+
+-- | Helper newtype to be used with `deriving via` to derive
+-- `(PQFormat, ToSQL, FromSQL)` instances for enums.
+newtype SQLEnum a = SQLEnum a
+
+class
+  ( -- The semantic type needs to be finitely enumerable,
+    Enum a
+  , Bounded a
+  -- and the target type has to be an enum with an SQL representation.
+  , FromSQL (SQLEnumType a)
+  , ToSQL (SQLEnumType a)
+  , PQFormat (SQLEnumType a)
+  -- Miscellaneous constraints:
+  , Enum (SQLEnumType a)
+  , Ord (SQLEnumType a)
+  , Show (SQLEnumType a)
+  , Typeable (SQLEnumType a)
+  ) => SQLEnumEncoding a where
+  type SQLEnumType a
+  encodeEnum :: a -> SQLEnumType a
+  decodeEnumMap :: Map (SQLEnumType a) a
+  decodeEnumMap = Map.fromList [ (encodeEnum a, a) | a <- enumerate ]
+
+instance SQLEnumEncoding a => PQFormat (SQLEnum a) where
+  pqFormat = pqFormat @(SQLEnumType a)
+
+instance SQLEnumEncoding a => ToSQL (SQLEnum a) where
+  type PQDest (SQLEnum a) = PQDest (SQLEnumType a)
+  toSQL (SQLEnum a) = toSQL $ encodeEnum a
+
+instance SQLEnumEncoding a => FromSQL (SQLEnum a) where
+  type PQBase (SQLEnum a) = PQBase (SQLEnumType a)
+  fromSQL base = do
+    b <- fromSQL base
+    case Map.lookup b decodeEnumMap of
+      Nothing -> throwIO $ SomeException RangeError
+        { reRange = intervals $ Map.keys (decodeEnumMap @a)
+        , reValue = b
+        }
+      Just a -> return $ SQLEnum a
+
+
+-- | A special case of `SQLEnum`, where the enum is to be encoded as text (and
+-- SQLEnum can't be used because of the `Enum (SQLEnumType)` constraint).
+newtype SQLEnumAsText a = SQLEnumAsText a
+
+class (Enum a , Bounded a) => SQLEnumAsTextEncoding a where
+  encodeEnumAsText :: a -> Text
+  decodeEnumAsTextMap :: Map Text a
+  decodeEnumAsTextMap = Map.fromList [ (encodeEnumAsText a, a) | a <- enumerate ]
+
+instance SQLEnumAsTextEncoding a => PQFormat (SQLEnumAsText a) where
+  pqFormat = pqFormat @Text
+
+instance SQLEnumAsTextEncoding a => ToSQL (SQLEnumAsText a) where
+  type PQDest (SQLEnumAsText a) = PQDest Text
+  toSQL (SQLEnumAsText a) = toSQL $ encodeEnumAsText a
+
+instance SQLEnumAsTextEncoding a => FromSQL (SQLEnumAsText a) where
+  type PQBase (SQLEnumAsText a) = PQBase Text
+  fromSQL base = do
+    text <- fromSQL base
+    case Map.lookup text decodeEnumAsTextMap of
+      Nothing -> throwIO $ SomeException InvalidValue
+        { ivValue       = text
+        , ivValidValues = Just $ Map.keys (decodeEnumAsTextMap @a)
+        }
+      Just a -> return $ SQLEnumAsText a

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module Database.PostgreSQL.PQTypes.Model.ColumnType (
     ColumnType(..)
   , columnTypeToSQL


### PR DESCRIPTION
Something broke with GitHub, it didn't see the commits I added.

Original PR: #38 

> Example usage:
> ```
> data Colours = Blue | Black | Red | Mauve
>   deriving (Enum, Bounded)
>   deriving (PQFormat, ToSQL, FromSQL) via SQLEnum Colours
> 
> instance SQLEnumEncoding Colours where
>   type SQLEnumType = Int16
>   encodeEnum = \case
>     Blue -> 1
>     Black -> 42
>     Red -> 1337
>     Mauve -> -1
> ```