### PR TITLE
Fix the lower bound of log-base

### DIFF
--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -87,7 +87,7 @@ library
                , monad-control     >= 1.0.3.1 && < 1.1
                , semigroups        >= 0.16    && < 0.20
                , text-show         >= 3.7     && < 4
-               , log-base          >= 0.7     && < 0.12
+               , log-base          >= 0.11    && < 0.12
                , safe              >= 0.3     && < 0.4
 
   default-language: Haskell2010


### PR DESCRIPTION
This matches the `-r1` revision: https://hackage.haskell.org/package/hpqtypes-extras-1.12.0.1/revisions/