### PR TITLE
Relax upper bound on `base16-bytestring`

### DIFF
--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -74,7 +74,7 @@ library
 
   build-depends: base              >= 4.9     && < 5
                , hpqtypes          >= 1.8.0.0 && < 2.0.0.0
-               , base16-bytestring >= 0.1     && < 1.0.2.0
+               , base16-bytestring >= 0.1     && < 1.1
                , bytestring        >= 0.10    && < 0.12
                , containers        >= 0.5     && < 0.7
                , cryptohash        >= 0.11    && < 0.12


### PR DESCRIPTION
See also https://github.com/commercialhaskell/stackage/issues/6261.