### PR TITLE
Remove weird conditional compilation

### DIFF
--- a/src/Database/PostgreSQL/PQTypes/Model/Migration.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Migration.hs
@@ -49,23 +49,13 @@ data MigrationAction m =
 
   -- | Migration for creating an index concurrently.
   | CreateIndexConcurrentlyMigration
-#if __GLASGOW_HASKELL__ >= 806
       (RawSQL ()) -- ^ Table name
       TableIndex  -- ^ Index
-#else
-      (RawSQL ())
-      TableIndex
-#endif
 
   -- | Migration for dropping an index concurrently.
   | DropIndexConcurrentlyMigration
-#if __GLASGOW_HASKELL__ >= 806
       (RawSQL ()) -- ^ Table name
       TableIndex  -- ^ Index
-#else
-      (RawSQL ())
-      TableIndex
-#endif
 
 -- | Migration object.
 data Migration m =


### PR DESCRIPTION
Since only GHC >= 8.8 is supported, the __GLASGOW_HASKELL__  >= 806 doesn't
seem to make any sense.