### PR TITLE
Make order of tables during schema creation irrelevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# hpqtypes-extras-1.16.4.2 (2023-??-??)
+* Make order of tables during schema creation irrelevant.
+
 # hpqtypes-extras-1.16.4.1 (2023-05-15)
 * Relax checks around indexes related to the `REINDEX` operation.
 

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                hpqtypes-extras
-version:             1.16.4.1
+version:             1.16.4.2
 synopsis:            Extra utilities for hpqtypes library
 description:         The following extras for hpqtypes library:
                      .

--- a/src/Database/PostgreSQL/PQTypes/Migrate.hs
+++ b/src/Database/PostgreSQL/PQTypes/Migrate.hs
@@ -25,6 +25,8 @@ createTable withConstraints table@Table{..} = do
   -- Create empty table and add the columns.
   runQuery_ $ sqlCreateTable tblName
   runQuery_ $ sqlAlterTable tblName $ map sqlAddColumn tblColumns
+  -- Add the primary key if applicable.
+  forM_ tblPrimaryKey $ \pk -> runQuery_ $ sqlAlterTable tblName [sqlAddPK tblName pk]
   -- Add indexes.
   forM_ tblIndexes $ runQuery_ . sqlCreateIndexMaybeDowntime tblName
   -- Add all the other constraints if applicable.
@@ -40,9 +42,8 @@ createTableConstraints :: MonadDB m => Table -> m ()
 createTableConstraints Table{..} = when (not $ null addConstraints) $ do
   runQuery_ $ sqlAlterTable tblName addConstraints
   where
-    addConstraints = concat [
-        [sqlAddPK tblName pk | Just pk <- return tblPrimaryKey]
-      , map sqlAddValidCheckMaybeDowntime tblChecks
+    addConstraints = concat
+      [ map sqlAddValidCheckMaybeDowntime tblChecks
       , map (sqlAddValidFKMaybeDowntime tblName) tblForeignKeys
       ]
 


### PR DESCRIPTION
Creation of primary key was unnecessarily omitted until second stage and created along with foreign keys, but a primary key includes a unique index, so it might have happened that a foreign key couldn't be created, because the primary key related index it needed wasn't created yet and order of tables on the list had to be adjusted.