### PR TITLE
Add support for NULLS NOT DISTINCT

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,7 +30,7 @@ jobs:
       image: buildpack-deps:jammy
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # hpqtypes-extras-1.17.0.0 (2023-??-??)
 * Add an optional check that all foreign keys have an index.
+* Add support for NULLS NOT DISTINCT in unique indexes.
 
 # hpqtypes-extras-1.16.4.4 (2023-08-23)
 * Switch from `cryptonite` to `crypton`.


### PR DESCRIPTION
This implements a feature request by @3kyro.

By default, NULL columns escape the UNIQUE constraint: two rows with NULL are not considered as equals, and therefore the unique is not violated. But we sometimes want to consider NULL as a proper value, equal to other NULLs. Adding `NULLS NOT DISTINCT` after `UNIQUE` does exactly that: you cannot insert a second row containing a NULL value on such an unique index.

Note that you can also add `UNIQUE NULLS DISTINCT` to explicitly state that you want the default behaviour (NULL values are treated as not equals), it's a bit redundant, so let's not do this.

This is an optional feature of the SQL standard defined in the 2023 version of the SQL standard, and implemented in postgres since version 15.

Which leads me to my main concern: I think we can live with supporting the _creation_ of NOT NULL DISTINCT on an outdated database, because the error message popped by postgres will be clear enough.

However, I'm afraid this will break the table checker if it's run of anything below 15, since I had to patch the query on `pg_catalog.pg_index` to include the `indnullsnotdistinct` column. @marco44, would you kindly confirm that this column does not exist prior to V15 ? Would you have an idiomatic syntax to suggest that would basically implement this logic:

```if current_version_of_pg > 14 then pg.catalog.pg_index else false)```