### PR TITLE
Fix overlapping index checking

### DIFF
--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -508,7 +508,7 @@ checkDBStructure options tables = fmap mconcat . forM tables $ \(table, version)
       runQuery_ $ sqlGetForeignKeys table
       fkeys <- fetchMany fetchForeignKey
       triggers <- getDBTriggers tblName
-      checkedOverlaps <- checkOverlappingIndexes (mkSQL . T.pack $ tblNameString table)
+      checkedOverlaps <- checkOverlappingIndexes tblName
       return $
         mconcat
           [ checkColumns 1 tblColumns desc
@@ -714,7 +714,7 @@ checkDBStructure options tables = fmap mconcat . forM tables $ \(table, version)
                      \expected output into source code.)"
                    ]
 
-        checkOverlappingIndexes :: MonadDB m => SQL -> m ValidationResult
+        checkOverlappingIndexes :: MonadDB m => RawSQL () -> m ValidationResult
         checkOverlappingIndexes tableName =
           if eoCheckOverlappingIndexes options
             then go

--- a/src/Database/PostgreSQL/PQTypes/Checks/Util.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks/Util.hs
@@ -190,7 +190,7 @@ objectHasMore otype ptype extra =
 arrListTable :: RawSQL () -> Text
 arrListTable tableName = " ->" <+> unRawSQL tableName <> ": "
 
-checkOverlappingIndexesQuery :: SQL -> SQL
+checkOverlappingIndexesQuery :: RawSQL () -> SQL
 checkOverlappingIndexesQuery tableName =
   smconcat
     [ "WITH"
@@ -202,7 +202,7 @@ checkOverlappingIndexesQuery tableName =
     , "                                        , 'WHERE (.*)$')))[1] AS preddef"
     , "                    FROM pg_index"
     , "                    WHERE indexprs IS NULL"
-    , "                    AND indrelid = '" <> tableName <> "'::regclass)"
+    , "                    AND indrelid = '" <> raw tableName <> "'::regclass)"
     , -- add the rest of metadata and do the join
       "   , indexdata2 AS (SELECT t1.*"
     , "                         , pg_get_indexdef(t1.indexrelid) AS contained"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2166,7 +2166,18 @@ overlapingIndexesTests connSource = do
   testCaseSteps' "Overlapping indexes tests" connSource $ \step -> do
     freshTestDB step
 
-    step "Check that overlapping indexes get flagged"
+    step "Migration is correct if not checking for overlapping indexes"
+    do
+      let options = defaultExtrasOptions {eoCheckOverlappingIndexes = False}
+      migrateDatabase
+        options
+        ["pgcrypto"]
+        []
+        []
+        [table1]
+        [createTableMigration table1]
+
+    step "Migration invalid when flagging overlapping indexes"
     do
       let options = defaultExtrasOptions {eoCheckOverlappingIndexes = True}
       assertException "Some indexes are overlapping" $
@@ -2181,7 +2192,7 @@ overlapingIndexesTests connSource = do
     table1 :: Table
     table1 =
       tblTable
-        { tblName = "idxTest"
+        { tblName = "idx_test"
         , tblVersion = 1
         , tblColumns =
             [ tblColumn {colName = "id", colType = UuidT, colNullable = False}


### PR DESCRIPTION
- Ensure we check only overlap on the current table and not the whole schema each time we check a table;
- Exclude local indexes;
- Make sure PK are not taken into account;
- Fix test (it was passing for the wrong reasons);