### PR TITLE
Extend the Trigger interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   nested `AND` and `OR` conditions.
 * Add `SqlWhereAll` and `SqlWhereAny` so they can be used in signatures.
 * Add rudimentary support for enum types.
+* Add support for some regular triggers, ie: `AFTER` triggers without constraints
+  and `BEFORE` triggers.
 
 # hpqtypes-extras-1.16.4.4 (2023-08-23)
 * Switch from `cryptonite` to `crypton`.

--- a/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
@@ -95,6 +95,7 @@ data Trigger = Trigger
   -- triggers of same table. See 'triggerMakeName'.
   , triggerKind :: TriggerKind
   -- ^ The kind of trigger we want to create.
+  -- @since 1.17.0.0
   , triggerEvents :: Set TriggerEvent
   -- ^ The set of events. Corresponds to the @{ __event__ [ OR ... ] }@ in the trigger
   -- definition. The order in which they are defined doesn't matter and there can

--- a/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
@@ -46,8 +46,6 @@ data TriggerRegularTiming
     After
   | -- | A @BEFORE@ trigger.
     Before
-  | -- | An @INSTEAD OF@ trigger.
-    InsteadOf
   deriving (Eq, Show)
 
 -- | Timing for a constraint trigger.
@@ -177,7 +175,6 @@ sqlCreateTrigger Trigger {..} =
     tgrTiming = case triggerKind of
       TriggerRegular After -> "AFTER"
       TriggerRegular Before -> "BEFORE"
-      TriggerRegular InsteadOf -> "INSTEAD OF"
       TriggerConstraint _ -> "AFTER"
     trgEvents
       | triggerEvents == Set.empty = error "Trigger must have at least one event."
@@ -307,7 +304,7 @@ getDBTriggers tableName = do
         tgrTiming = case (tgtypeInsteadBit, tgtypeBeforeBit) of
           (False, False) -> After
           (False, True) -> Before
-          (True, False) -> InsteadOf
+          (True, False) -> error "INSTEAD OF triggers are not available on tables."
           (True, True) -> error "The tgtype can't match more than one timing."
           where
             -- Taken from PostgreSQL sources: src/include/catalog/pg_trigger.h:

--- a/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
@@ -28,6 +28,7 @@ module Database.PostgreSQL.PQTypes.Model.Trigger
 import Data.Bits (testBit)
 import Data.Foldable (foldl')
 import Data.Int
+import Data.Monoid.Extra
 import Data.Monoid.Utils
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -169,11 +170,8 @@ sqlCreateTrigger Trigger {..} =
     trgConstraintTiming
       | not triggerConstraint = ""
       | otherwise =
-          let deferrable = (if triggerDeferrable then "" else "NOT") <+> "DEFERRABLE"
-              deferred =
-                if triggerInitiallyDeferred
-                  then "INITIALLY DEFERRED"
-                  else "INITIALLY IMMEDIATE"
+          let deferrable = mwhen (not triggerDeferrable) "NOT" <+> "DEFERRABLE"
+              deferred = "INITIALLY" <+> if triggerInitiallyDeferred then "DEFERRED" else "IMMEDIATE"
           in deferrable <+> deferred
     trgWhen = maybe "" (\w -> "WHEN (" <+> w <+> ")") triggerWhen
     trgFunction = triggerFunctionMakeName triggerName

--- a/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Trigger.hs
@@ -38,7 +38,7 @@ import Data.Text qualified as Text
 import Database.PostgreSQL.PQTypes
 import Database.PostgreSQL.PQTypes.SQL.Builder
 
--- | Timing for a regault trigger.
+-- | Timing for a regular trigger.
 --
 -- @since 1.17.0.0
 data TriggerActionTime

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -40,7 +40,7 @@ instance IsOption ConnectionString where
   defaultValue =
     ConnectionString
       -- For GitHub Actions CI
-      "host=postgres user=postgres password=postgres"
+      "host=localhost port=15432 user=postgres password=postgres"
   parseValue = Just . ConnectionString
   optionName = return "connection-string"
   optionHelp = return "Postgres connection string"
@@ -1124,11 +1124,8 @@ bankTrigger1 =
   Trigger
     { triggerTable = "bank"
     , triggerName = "trigger_1"
-    , triggerConstraint = True
-    , triggerTiming = TriggerAfter
+    , triggerKind = TriggerConstraint NotDeferrable
     , triggerEvents = Set.fromList [TriggerInsert]
-    , triggerDeferrable = False
-    , triggerInitiallyDeferred = False
     , triggerWhen = Nothing
     , triggerFunction =
         "begin"
@@ -1151,11 +1148,8 @@ bankTrigger3 =
   Trigger
     { triggerTable = "bank"
     , triggerName = "trigger_3"
-    , triggerConstraint = True
-    , triggerTiming = TriggerAfter
+    , triggerKind = TriggerConstraint DeferrableInitiallyDeferred
     , triggerEvents = Set.fromList [TriggerInsert, TriggerUpdateOf [unsafeSQL "location"]]
-    , triggerDeferrable = True
-    , triggerInitiallyDeferred = True
     , triggerWhen = Nothing
     , triggerFunction =
         "begin"
@@ -1322,8 +1316,8 @@ testTriggers step = do
       verify [trg] True
 
   do
-    let msg = "successfully migrate trigger that is deferrable"
-        trg = bankTrigger1 {triggerDeferrable = True}
+    let msg = "successfully migrate a constraint trigger that is deferrable"
+        trg = bankTrigger1 {triggerKind = TriggerConstraint DeferrableInitiallyImmediate}
         ts =
           [ tableBankSchema1
               { tblVersion = 2
@@ -1336,12 +1330,8 @@ testTriggers step = do
       verify [trg] True
 
   do
-    let msg = "successfully migrate trigger that is deferrable and initially deferred"
-        trg =
-          bankTrigger1
-            { triggerDeferrable = True
-            , triggerInitiallyDeferred = True
-            }
+    let msg = "successfully migrate a constraint trigger that is deferrable and initially deferred"
+        trg = bankTrigger1 {triggerKind = TriggerConstraint DeferrableInitiallyDeferred}
         ts =
           [ tableBankSchema1
               { tblVersion = 2
@@ -1354,12 +1344,8 @@ testTriggers step = do
       verify [trg] True
 
   do
-    let msg = "database exception is raised if trigger is initially deferred but not deferrable"
-        trg =
-          bankTrigger1
-            { triggerDeferrable = False
-            , triggerInitiallyDeferred = True
-            }
+    let msg = "successfully migrate a regular AFTER trigger"
+        trg = bankTrigger1 {triggerKind = TriggerRegular After}
         ts =
           [ tableBankSchema1
               { tblVersion = 2
@@ -1368,7 +1354,36 @@ testTriggers step = do
           ]
         ms = [createTriggerMigration 1 trg]
     triggerStep msg $ do
-      assertDBException msg $ migrate ts ms
+      assertNoException msg $ migrate ts ms
+      verify [trg] True
+
+  do
+    let msg = "successfully migrate a regular BEFORE trigger"
+        trg = bankTrigger1 {triggerKind = TriggerRegular Before}
+        ts =
+          [ tableBankSchema1
+              { tblVersion = 2
+              , tblTriggers = [trg]
+              }
+          ]
+        ms = [createTriggerMigration 1 trg]
+    triggerStep msg $ do
+      assertNoException msg $ migrate ts ms
+      verify [trg] True
+
+  do
+    let msg = "successfully migrate a regular INSTEAD OF trigger"
+        trg = bankTrigger1 {triggerKind = TriggerRegular InsteadOf}
+        ts =
+          [ tableBankSchema1
+              { tblVersion = 2
+              , tblTriggers = [trg]
+              }
+          ]
+        ms = [createTriggerMigration 1 trg]
+    triggerStep msg $ do
+      assertNoException msg $ migrate ts ms
+      verify [trg] True
 
   do
     let msg = "database exception is raised if dropping trigger that does not exist"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1124,6 +1124,8 @@ bankTrigger1 =
   Trigger
     { triggerTable = "bank"
     , triggerName = "trigger_1"
+    , triggerConstraint = True
+    , triggerTiming = TriggerAfter
     , triggerEvents = Set.fromList [TriggerInsert]
     , triggerDeferrable = False
     , triggerInitiallyDeferred = False
@@ -1149,6 +1151,8 @@ bankTrigger3 =
   Trigger
     { triggerTable = "bank"
     , triggerName = "trigger_3"
+    , triggerConstraint = True
+    , triggerTiming = TriggerAfter
     , triggerEvents = Set.fromList [TriggerInsert, TriggerUpdateOf [unsafeSQL "location"]]
     , triggerDeferrable = True
     , triggerInitiallyDeferred = True

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1317,7 +1317,7 @@ testTriggers step = do
 
   do
     let msg = "successfully migrate a constraint trigger that is deferrable"
-        trg = bankTrigger1 {triggerKind = TriggerConstraint DeferrableInitiallyImmediate}
+        trg = bankTrigger1 {triggerKind = TriggerConstraint Deferrable}
         ts =
           [ tableBankSchema1
               { tblVersion = 2

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1372,20 +1372,6 @@ testTriggers step = do
       verify [trg] True
 
   do
-    let msg = "successfully migrate a regular INSTEAD OF trigger"
-        trg = bankTrigger1 {triggerKind = TriggerRegular InsteadOf}
-        ts =
-          [ tableBankSchema1
-              { tblVersion = 2
-              , tblTriggers = [trg]
-              }
-          ]
-        ms = [createTriggerMigration 1 trg]
-    triggerStep msg $ do
-      assertNoException msg $ migrate ts ms
-      verify [trg] True
-
-  do
     let msg = "database exception is raised if dropping trigger that does not exist"
         trg = bankTrigger1
         ts =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -40,7 +40,7 @@ instance IsOption ConnectionString where
   defaultValue =
     ConnectionString
       -- For GitHub Actions CI
-      "postgres user=postgres password=postgres"
+      "host=postgres user=postgres password=postgres"
   parseValue = Just . ConnectionString
   optionName = return "connection-string"
   optionHelp = return "Postgres connection string"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -40,7 +40,7 @@ instance IsOption ConnectionString where
   defaultValue =
     ConnectionString
       -- For GitHub Actions CI
-      "host=localhost port=15432 user=postgres password=postgres"
+      "postgres user=postgres password=postgres"
   parseValue = Just . ConnectionString
   optionName = return "connection-string"
   optionHelp = return "Postgres connection string"


### PR DESCRIPTION
This PR proposes to extend the `Trigger` interface to allow the creation of triggers without the `CONSTRAINT` keyword.