### PR TITLE
Improve handling of lock failures during migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # hpqtypes-extras-1.18.0.0 (2025-??-??)
 * Don't consider invalid indexes when checking consistency of the database.
+* Improve handling of lock failures during migrations.
 
 # hpqtypes-extras-1.17.0.1 (2025-03-27)
 * Fix validation of NOT NULL domains with PostgreSQL >= 17.

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -36,6 +36,7 @@ common common-stanza
                     , ImportQualifiedPost
                     , LambdaCase
                     , MultiWayIf
+                    , NumericUnderscores
                     , OverloadedStrings
                     , RankNTypes
                     , RecordWildCards

--- a/src/Database/PostgreSQL/PQTypes/ExtrasOptions.hs
+++ b/src/Database/PostgreSQL/PQTypes/ExtrasOptions.hs
@@ -6,7 +6,9 @@ module Database.PostgreSQL.PQTypes.ExtrasOptions
 
 data ExtrasOptions
   = ExtrasOptions
-  { eoLockTimeoutMs :: !(Maybe Int)
+  { eoLockTimeoutMs :: !Int
+  , eoLockFailureBackoffSecs :: !Int
+  , eoLockAttempts :: !Int
   , eoEnforcePKs :: !Bool
   -- ^ Validate that every handled table has a primary key
   , eoObjectsValidationMode :: !ObjectsValidationMode
@@ -24,7 +26,9 @@ data ExtrasOptions
 defaultExtrasOptions :: ExtrasOptions
 defaultExtrasOptions =
   ExtrasOptions
-    { eoLockTimeoutMs = Nothing
+    { eoLockTimeoutMs = 3000
+    , eoLockFailureBackoffSecs = 30
+    , eoLockAttempts = 5
     , eoEnforcePKs = False
     , eoObjectsValidationMode = DontAllowUnknownObjects
     , eoAllowHigherTableVersions = False

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -890,7 +890,7 @@ migrateDBToSchema2 step = do
   let definitions = tableDefsWithPgCrypto schema2Tables
   step "Migrating the database (schema version 1 -> schema version 2)..."
   migrateDatabase
-    defaultExtrasOptions {eoLockTimeoutMs = Just 1000}
+    defaultExtrasOptions
     definitions
     schema2Migrations
   checkDatabase defaultExtrasOptions definitions


### PR DESCRIPTION
1. Added configurable backoff and made the default 30 seconds. A second didn't make much sense, because if taking a lock didn't work, the database was pressured more because of waiting queries so lock attempt was more likely to fail the second time etc.

2. There's now a maximum number of attempts before it aborts. Previously it would try indefinitely, significantly degrading responsiveness of the database until manually killed.