### PR TITLE
Allow using nonreserved keywords in table indices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Adds a `Function` datatype and a `defaultTriggerFunction` backwards-compatible
   trigger function helper.
 * Remove `Read` instance of `IndexMethod`.
+* Allow using nonreserved keywords, e.g. `timestamp`, in table indices.
 
 # hpqtypes-extras-1.19.0.0 (2025-11-27)
 * Compatibility with `hpqtypes` >= 0.13.0.0.

--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -950,8 +950,10 @@ checkDBConsistency options domains enums tablesWithVersions migrations = do
             [ mgrs | mgrs <- migrationsByTable, any isDropTableMigration mgrs
             ]
           invalidMigrationLists =
-            [ mgrs | mgrs <- dropMigrationLists, (not . isDropTableMigration . last $ mgrs)
-                                                  || (length . filter isDropTableMigration $ mgrs) > 1
+            [ mgrs
+            | mgrs <- dropMigrationLists
+            , (not . isDropTableMigration . last $ mgrs)
+                || (length . filter isDropTableMigration $ mgrs) > 1
             ]
 
       unless (null invalidMigrationLists) $ do
@@ -1550,7 +1552,6 @@ fetchTableIndex (name, Array1 keyColumns, Array1 includeColumns, method, unique,
     stripIdentifierQuotes str = case fmap T.unsnoc <$> T.uncons str of
       Just ('"', Just (identifier, '"')) -> identifier
       _ -> str
-
 
 -- *** FOREIGN KEYS ***
 

--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -1534,8 +1534,8 @@ fetchTableIndex
   -> (TableIndex, RawSQL ())
 fetchTableIndex (name, Array1 keyColumns, Array1 includeColumns, method, unique, nullsNotDistinct, mconstraint) =
   ( TableIndex
-      { idxColumns = map (indexColumn . (`rawSQL` ())) keyColumns
-      , idxInclude = map (`rawSQL` ()) includeColumns
+      { idxColumns = map (indexColumn . (`rawSQL` ()) . stripIdentifierQuotes) keyColumns
+      , idxInclude = map ((`rawSQL` ()) . stripIdentifierQuotes) includeColumns
       , idxMethod = case method of
           "gin" -> GIN
           "btree" -> BTree
@@ -1546,6 +1546,11 @@ fetchTableIndex (name, Array1 keyColumns, Array1 includeColumns, method, unique,
       }
   , rawSQL name ()
   )
+  where
+    stripIdentifierQuotes str = case fmap T.unsnoc <$> T.uncons str of
+      Just ('"', Just (identifier, '"')) -> identifier
+      _ -> str
+
 
 -- *** FOREIGN KEYS ***
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2325,6 +2325,102 @@ nullsNotDistinctTests connSource = do
             ]
         }
 
+reservedWordColumnTests :: ConnectionSourceM (LogT IO) -> TestTree
+reservedWordColumnTests connSource =
+  testCaseSteps' "Reserved word column tests" connSource $ \step -> do
+    freshTestDB step
+
+    step "Create a table with a plain index on a 'timestamp' column"
+    assertNoException "Table with index on 'timestamp' column should be created successfully" $ do
+      let definitions = tableDefsWithPgCrypto [tableWithTimestampIndex]
+      migrateDatabase
+        defaultExtrasOptions
+        definitions
+        [createTableMigration tableWithTimestampIndex]
+      checkDatabase defaultExtrasOptions definitions
+
+    freshTestDB step
+
+    step "Create a table with a unique index on a 'timestamp' column"
+    assertNoException "Table with unique index on 'timestamp' column should be created successfully" $ do
+      let definitions = tableDefsWithPgCrypto [tableWithUniqueTimestampIndex]
+      migrateDatabase
+        defaultExtrasOptions
+        definitions
+        [createTableMigration tableWithUniqueTimestampIndex]
+      checkDatabase defaultExtrasOptions definitions
+
+    freshTestDB step
+
+    step "Create a table with a composite index including a 'timestamp' column"
+    assertNoException "Table with composite index on 'timestamp' column should be created successfully" $ do
+      let definitions = tableDefsWithPgCrypto [tableWithCompositeTimestampIndex]
+      migrateDatabase
+        defaultExtrasOptions
+        definitions
+        [createTableMigration tableWithCompositeTimestampIndex]
+      checkDatabase defaultExtrasOptions definitions
+
+    freshTestDB step
+
+    step "Attempt to create a table with an index on a 'select' column"
+    assertException "Table with index on 'select' column can't be created" $ do
+      let definitions = tableDefsWithPgCrypto [tableWithSelectIndex]
+      migrateDatabase
+        defaultExtrasOptions
+        definitions
+        [createTableMigration tableWithSelectIndex]
+      checkDatabase defaultExtrasOptions definitions
+  where
+    tableWithTimestampIndex =
+      tblTable
+        { tblName = "reserved_word_test1"
+        , tblVersion = 1
+        , tblColumns =
+            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
+            , tblColumn {colName = "timestamp", colType = TimestampWithZoneT, colNullable = False}
+            ]
+        , tblPrimaryKey = pkOnColumn "id"
+        , tblIndexes = [indexOnColumn "timestamp"]
+        }
+
+    tableWithUniqueTimestampIndex =
+      tblTable
+        { tblName = "reserved_word_test2"
+        , tblVersion = 1
+        , tblColumns =
+            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
+            , tblColumn {colName = "timestamp", colType = TimestampWithZoneT, colNullable = False}
+            ]
+        , tblPrimaryKey = pkOnColumn "id"
+        , tblIndexes = [uniqueIndexOnColumn "timestamp"]
+        }
+
+    tableWithCompositeTimestampIndex =
+      tblTable
+        { tblName = "reserved_word_test3"
+        , tblVersion = 1
+        , tblColumns =
+            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
+            , tblColumn {colName = "timestamp", colType = TimestampWithZoneT, colNullable = False}
+            , tblColumn {colName = "name", colType = TextT, colNullable = True}
+            ]
+        , tblPrimaryKey = pkOnColumn "id"
+        , tblIndexes = [indexOnColumns [indexColumn "timestamp", indexColumn "name"]]
+        }
+
+    tableWithSelectIndex =
+      tblTable
+        { tblName = "reserved_word_test4"
+        , tblVersion = 1
+        , tblColumns =
+            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
+            , tblColumn {colName = "select", colType = TextT, colNullable = True}
+            ]
+        , tblPrimaryKey = pkOnColumn "id"
+        , tblIndexes = [indexOnColumn "select"]
+        }
+
 sqlAnyAllTests :: TestTree
 sqlAnyAllTests =
   testGroup
@@ -2551,6 +2647,7 @@ main = do
           , foreignKeyIndexesTests connSource
           , overlapingIndexesTests connSource
           , nullsNotDistinctTests connSource
+          , reservedWordColumnTests connSource
           , sqlAnyAllTests
           , enumTest connSource
           ]


### PR DESCRIPTION
It appears postgres internally quotes keywords, even nonreserved ones, when they're used as column names. So even though you are able to use them unquoted in SQL statements, they internally exist quoted. This PR strips the quoting so it matches up how the user types the column, when it is checked during validation.