### PR TITLE
Add numeric type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   trigger function helper.
 * Remove `Read` instance of `IndexMethod`.
 * Allow using nonreserved keywords, e.g. `timestamp`, in table indices.
+* Add support for the `NUMERIC` column type.
 
 # hpqtypes-extras-1.19.0.0 (2025-11-27)
 * Compatibility with `hpqtypes` >= 0.13.0.0.

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -96,6 +96,7 @@ library
                , text              >= 1.2
                , text-show         >= 3.7
                , attoparsec        >= 0.14.4
+
   default-language: Haskell2010
   default-extensions:
 

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -95,6 +95,7 @@ library
                , ppad-ripemd160    >= 0.1.4
                , text              >= 1.2
                , text-show         >= 3.7
+               , attoparsec
 
   default-language: Haskell2010
   default-extensions:

--- a/hpqtypes-extras.cabal
+++ b/hpqtypes-extras.cabal
@@ -95,8 +95,7 @@ library
                , ppad-ripemd160    >= 0.1.4
                , text              >= 1.2
                , text-show         >= 3.7
-               , attoparsec
-
+               , attoparsec        >= 0.14.4
   default-language: Haskell2010
   default-extensions:
 

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -29,32 +29,8 @@ data ColumnType
   | XmlT
   | ArrayT !ColumnType
   | CustomT !(RawSQL ())
-  | NumericT !(Maybe (Int, Maybe Int))
-  deriving (Ord, Show)
-
-instance Eq ColumnType where
-  BigIntT == BigIntT = True
-  BigSerialT == BigSerialT = True
-  BinaryT == BinaryT = True
-  BoolT == BoolT = True
-  DateT == DateT = True
-  DoubleT == DoubleT = True
-  IntegerT == IntegerT = True
-  UuidT == UuidT = True
-  IntervalT == IntervalT = True
-  JsonT == JsonT = True
-  JsonbT == JsonbT = True
-  SmallIntT == SmallIntT = True
-  TextT == TextT = True
-  TimestampWithZoneT == TimestampWithZoneT = True
-  TSVectorT == TSVectorT = True
-  XmlT == XmlT = True
-  ArrayT t == ArrayT t' = t == t'
-  CustomT t == CustomT t' = t == t'
-  NumericT (Just (precision, Nothing)) == NumericT (Just (precision', Just 0)) = precision == precision'
-  NumericT (Just (precision, Just 0)) == NumericT (Just (precision', Nothing)) = precision == precision'
-  NumericT mPrecisionScale == NumericT mPrecisionScale' = mPrecisionScale == mPrecisionScale'
-  _ == _ = False
+  | NumericT !(Maybe (Int, Int))
+  deriving (Eq, Ord, Show)
 
 instance PQFormat ColumnType where
   pqFormat = pqFormat @T.Text
@@ -89,16 +65,8 @@ parseNumeric :: T.Text -> Maybe ColumnType
 parseNumeric tname =
   let inParens p = A.string "(" *> p <* A.string ")"
       comma = A.string "," $> ()
-      scale = do
-        s <- A.signed A.decimal
-        pure $
-          if s == 0
-            then
-              Nothing
-            else
-              Just s
-      precisionAndScale = Just <$> inParens ((,) <$> (A.decimal <* comma) <*> scale)
-      precisionOnly = Just . (,Nothing) <$> inParens A.decimal
+      precisionAndScale = Just <$> inParens ((,) <$> (A.decimal <* comma) <*> A.signed A.decimal)
+      precisionOnly = Just . (,0) <$> inParens A.decimal
       numericParser =
         NumericT
           <$> ( A.string "numeric"
@@ -130,6 +98,4 @@ columnTypeToSQL XmlT = "XML"
 columnTypeToSQL (ArrayT t) = columnTypeToSQL t <> "[]"
 columnTypeToSQL (CustomT tname) = tname
 columnTypeToSQL (NumericT Nothing) = rawSQL "NUMERIC" ()
-columnTypeToSQL (NumericT (Just (precision, Nothing))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> ")") ()
-columnTypeToSQL (NumericT (Just (precision, Just 0))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> ")") ()
-columnTypeToSQL (NumericT (Just (precision, Just scale))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> "," <> T.pack (show scale) <> ")") ()
+columnTypeToSQL (NumericT (Just (precision, scale))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> "," <> T.pack (show scale) <> ")") ()

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -3,6 +3,8 @@ module Database.PostgreSQL.PQTypes.Model.ColumnType
   , columnTypeToSQL
   ) where
 
+import Data.Attoparsec.Text qualified as A
+import Data.Functor
 import Data.Text qualified as T
 import Database.PostgreSQL.PQTypes
 
@@ -25,6 +27,7 @@ data ColumnType
   | XmlT
   | ArrayT !ColumnType
   | CustomT !(RawSQL ())
+  | NumericT !(Maybe (Int, Maybe Int))
   deriving (Eq, Ord, Show)
 
 instance PQFormat ColumnType where
@@ -32,27 +35,54 @@ instance PQFormat ColumnType where
 instance FromSQL ColumnType where
   type PQBase ColumnType = PQBase T.Text
   fromSQL mbase = parseType . T.toLower <$> fromSQL mbase
-    where
-      parseType :: T.Text -> ColumnType
-      parseType = \case
-        "bigint" -> BigIntT
-        "bytea" -> BinaryT
-        "boolean" -> BoolT
-        "date" -> DateT
-        "double precision" -> DoubleT
-        "integer" -> IntegerT
-        "uuid" -> UuidT
-        "interval" -> IntervalT
-        "json" -> JsonT
-        "jsonb" -> JsonbT
-        "smallint" -> SmallIntT
-        "text" -> TextT
-        "timestamp with time zone" -> TimestampWithZoneT
-        "tsvector" -> TSVectorT
-        "xml" -> XmlT
-        tname
-          | "[]" `T.isSuffixOf` tname -> ArrayT . parseType $ T.take (T.length tname - 2) tname
-          | otherwise -> CustomT $ rawSQL tname ()
+
+parseType :: T.Text -> ColumnType
+parseType = \case
+  "bigint" -> BigIntT
+  "bytea" -> BinaryT
+  "boolean" -> BoolT
+  "date" -> DateT
+  "double precision" -> DoubleT
+  "integer" -> IntegerT
+  "uuid" -> UuidT
+  "interval" -> IntervalT
+  "json" -> JsonT
+  "jsonb" -> JsonbT
+  "smallint" -> SmallIntT
+  "text" -> TextT
+  "timestamp with time zone" -> TimestampWithZoneT
+  "tsvector" -> TSVectorT
+  "xml" -> XmlT
+  tname -> case parseNumeric tname of
+    Just t -> t
+    Nothing
+      | "[]" `T.isSuffixOf` tname -> ArrayT . parseType $ T.take (T.length tname - 2) tname
+      | otherwise -> CustomT $ rawSQL tname ()
+
+parseNumeric :: T.Text -> Maybe ColumnType
+parseNumeric tname =
+  let inParens p = A.string "(" *> p <* A.string ")"
+      comma = A.string "," $> ()
+      scale = do
+        s <- A.signed A.decimal
+        pure $
+          if s == 0
+            then
+              Nothing
+            else
+              Just s
+      precisionAndScale = Just <$> inParens ((,) <$> (A.decimal <* comma) <*> scale)
+      precisionOnly = Just . (,Nothing) <$> inParens A.decimal
+      numericParser =
+        NumericT
+          <$> ( A.string "numeric"
+                  *> A.choice
+                    [ precisionAndScale
+                    , precisionOnly
+                    , pure Nothing
+                    ]
+              )
+  in either (const Nothing) Just $ A.parseOnly numericParser tname
 
 columnTypeToSQL :: ColumnType -> RawSQL ()
 columnTypeToSQL BigIntT = "BIGINT"
@@ -73,3 +103,15 @@ columnTypeToSQL TimestampWithZoneT = "TIMESTAMPTZ"
 columnTypeToSQL XmlT = "XML"
 columnTypeToSQL (ArrayT t) = columnTypeToSQL t <> "[]"
 columnTypeToSQL (CustomT tname) = tname
+columnTypeToSQL (NumericT mPrecision) =
+  let typeName =
+        "NUMERIC"
+          <> case mPrecision of
+            Just (precision, mScale) ->
+              "("
+                <> T.pack (show precision)
+                <> case mScale of
+                  Just scale -> "," <> T.pack (show scale) <> ")"
+                  Nothing -> ")"
+            Nothing -> ""
+  in rawSQL typeName ()

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
-
 module Database.PostgreSQL.PQTypes.Model.ColumnType
   ( ColumnType (..)
   , columnTypeToSQL
@@ -9,6 +7,7 @@ import Data.Attoparsec.Text qualified as A
 import Data.Functor
 import Data.Text qualified as T
 import Database.PostgreSQL.PQTypes
+import TextShow
 
 data ColumnType
   = BigIntT
@@ -37,46 +36,45 @@ instance PQFormat ColumnType where
 instance FromSQL ColumnType where
   type PQBase ColumnType = PQBase T.Text
   fromSQL mbase = parseType . T.toLower <$> fromSQL mbase
-
-parseType :: T.Text -> ColumnType
-parseType = \case
-  "bigint" -> BigIntT
-  "bytea" -> BinaryT
-  "boolean" -> BoolT
-  "date" -> DateT
-  "double precision" -> DoubleT
-  "integer" -> IntegerT
-  "uuid" -> UuidT
-  "interval" -> IntervalT
-  "json" -> JsonT
-  "jsonb" -> JsonbT
-  "smallint" -> SmallIntT
-  "text" -> TextT
-  "timestamp with time zone" -> TimestampWithZoneT
-  "tsvector" -> TSVectorT
-  "xml" -> XmlT
-  tname -> case parseNumeric tname of
-    Just t -> t
-    Nothing
-      | "[]" `T.isSuffixOf` tname -> ArrayT . parseType $ T.take (T.length tname - 2) tname
-      | otherwise -> CustomT $ rawSQL tname ()
-
-parseNumeric :: T.Text -> Maybe ColumnType
-parseNumeric tname =
-  let inParens p = A.string "(" *> p <* A.string ")"
-      comma = A.string "," $> ()
-      precisionAndScale = Just <$> inParens ((,) <$> (A.decimal <* comma) <*> A.signed A.decimal)
-      precisionOnly = Just . (,0) <$> inParens A.decimal
-      numericParser =
-        NumericT
-          <$> ( A.string "numeric"
-                  *> A.choice
-                    [ precisionAndScale
-                    , precisionOnly
-                    , pure Nothing
-                    ]
-              )
-  in either (const Nothing) Just $ A.parseOnly numericParser tname
+    where
+      parseType :: T.Text -> ColumnType
+      parseType = \case
+        "bigint" -> BigIntT
+        "bytea" -> BinaryT
+        "boolean" -> BoolT
+        "date" -> DateT
+        "double precision" -> DoubleT
+        "integer" -> IntegerT
+        "uuid" -> UuidT
+        "interval" -> IntervalT
+        "json" -> JsonT
+        "jsonb" -> JsonbT
+        "smallint" -> SmallIntT
+        "text" -> TextT
+        "timestamp with time zone" -> TimestampWithZoneT
+        "tsvector" -> TSVectorT
+        "xml" -> XmlT
+        tname -> case parseNumeric tname of
+          Just t -> t
+          Nothing
+            | "[]" `T.isSuffixOf` tname -> ArrayT . parseType $ T.take (T.length tname - 2) tname
+            | otherwise -> CustomT $ rawSQL tname ()
+      parseNumeric :: T.Text -> Maybe ColumnType
+      parseNumeric tname =
+        let inParens p = A.string "(" *> p <* A.string ")"
+            comma = A.string "," $> ()
+            precisionAndScale = Just <$> inParens ((,) <$> (A.decimal <* comma) <*> A.signed A.decimal)
+            precisionOnly = Just . (,0) <$> inParens A.decimal
+            numericParser =
+              NumericT
+                <$> ( A.string "numeric"
+                        *> A.choice
+                          [ precisionAndScale
+                          , precisionOnly
+                          , pure Nothing
+                          ]
+                    )
+        in either (const Nothing) Just $ A.parseOnly numericParser tname
 
 columnTypeToSQL :: ColumnType -> RawSQL ()
 columnTypeToSQL BigIntT = "BIGINT"
@@ -98,4 +96,4 @@ columnTypeToSQL XmlT = "XML"
 columnTypeToSQL (ArrayT t) = columnTypeToSQL t <> "[]"
 columnTypeToSQL (CustomT tname) = tname
 columnTypeToSQL (NumericT Nothing) = rawSQL "NUMERIC" ()
-columnTypeToSQL (NumericT (Just (precision, scale))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> "," <> T.pack (show scale) <> ")") ()
+columnTypeToSQL (NumericT (Just (precision, scale))) = rawSQL ("NUMERIC(" <> showt precision <> "," <> showt scale <> ")") ()

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
 module Database.PostgreSQL.PQTypes.Model.ColumnType
   ( ColumnType (..)
   , columnTypeToSQL
@@ -28,7 +30,31 @@ data ColumnType
   | ArrayT !ColumnType
   | CustomT !(RawSQL ())
   | NumericT !(Maybe (Int, Maybe Int))
-  deriving (Eq, Ord, Show)
+  deriving (Ord, Show)
+
+instance Eq ColumnType where
+  BigIntT == BigIntT = True
+  BigSerialT == BigSerialT = True
+  BinaryT == BinaryT = True
+  BoolT == BoolT = True
+  DateT == DateT = True
+  DoubleT == DoubleT = True
+  IntegerT == IntegerT = True
+  UuidT == UuidT = True
+  IntervalT == IntervalT = True
+  JsonT == JsonT = True
+  JsonbT == JsonbT = True
+  SmallIntT == SmallIntT = True
+  TextT == TextT = True
+  TimestampWithZoneT == TimestampWithZoneT = True
+  TSVectorT == TSVectorT = True
+  XmlT == XmlT = True
+  ArrayT t == ArrayT t' = t == t'
+  CustomT t == CustomT t' = t == t'
+  NumericT (Just (precision, Nothing)) == NumericT (Just (precision', Just 0)) = precision == precision'
+  NumericT (Just (precision, Just 0)) == NumericT (Just (precision', Nothing)) = precision == precision'
+  NumericT mPrecisionScale == NumericT mPrecisionScale' = mPrecisionScale == mPrecisionScale'
+  _ == _ = False
 
 instance PQFormat ColumnType where
   pqFormat = pqFormat @T.Text
@@ -111,6 +137,7 @@ columnTypeToSQL (NumericT mPrecision) =
               "("
                 <> T.pack (show precision)
                 <> case mScale of
+                  Just scale | scale == 0 -> ")"
                   Just scale -> "," <> T.pack (show scale) <> ")"
                   Nothing -> ")"
             Nothing -> ""

--- a/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/ColumnType.hs
@@ -129,16 +129,7 @@ columnTypeToSQL TimestampWithZoneT = "TIMESTAMPTZ"
 columnTypeToSQL XmlT = "XML"
 columnTypeToSQL (ArrayT t) = columnTypeToSQL t <> "[]"
 columnTypeToSQL (CustomT tname) = tname
-columnTypeToSQL (NumericT mPrecision) =
-  let typeName =
-        "NUMERIC"
-          <> case mPrecision of
-            Just (precision, mScale) ->
-              "("
-                <> T.pack (show precision)
-                <> case mScale of
-                  Just scale | scale == 0 -> ")"
-                  Just scale -> "," <> T.pack (show scale) <> ")"
-                  Nothing -> ")"
-            Nothing -> ""
-  in rawSQL typeName ()
+columnTypeToSQL (NumericT Nothing) = rawSQL "NUMERIC" ()
+columnTypeToSQL (NumericT (Just (precision, Nothing))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> ")") ()
+columnTypeToSQL (NumericT (Just (precision, Just 0))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> ")") ()
+columnTypeToSQL (NumericT (Just (precision, Just scale))) = rawSQL ("NUMERIC(" <> T.pack (show precision) <> "," <> T.pack (show scale) <> ")") ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2623,6 +2623,67 @@ tableDefsWithPgCrypto tables =
               ]
         }
 
+numericColumnTypeTestTable :: Table
+numericColumnTypeTestTable =
+  tblTable
+    { tblName = "unicorns"
+    , tblVersion = 1
+    , tblColumns =
+        [ tblColumn
+            { colName = "id"
+            , colType = UuidT
+            , colNullable = False
+            , colDefault = Just "gen_random_uuid()"
+            }
+        , tblColumn
+            { colName = "balance"
+            , colType = NumericT Nothing
+            , colCollation = Nothing
+            , colNullable = False
+            }
+        , tblColumn
+            { colName = "employees"
+            , colType = NumericT (Just (5, Nothing))
+            , colCollation = Nothing
+            , colNullable = False
+            }
+        , tblColumn
+            { colName = "foo"
+            , colType = NumericT (Just (5, Just 2))
+            , colCollation = Nothing
+            , colNullable = False
+            }
+        ]
+    , tblPrimaryKey = pkOnColumn "id"
+    , tblTriggers = []
+    }
+
+numericColumnTypeTestMigration :: MonadDB m => Migration m
+numericColumnTypeTestMigration =
+  let tableName = tblName numericColumnTypeTestTable
+  in Migration
+       { mgrTableName = tableName
+       , mgrFrom = 0
+       , mgrAction = StandardMigration $ do
+           runQuery_
+             $ sqlAlterTable
+               tableName
+             $ sqlAddColumn <$> tblColumns numericColumnTypeTestTable
+       }
+
+numericColumnTypeTest :: ConnectionSourceM (LogT IO) -> TestTree
+numericColumnTypeTest connSource =
+  testCaseSteps' "NUMERIC column test" connSource $ \step -> do
+    freshTestDB step
+
+    let dbDefinitions = emptyDbDefinitions {dbTables = [numericColumnTypeTestTable]}
+
+    step "run the migration"
+    migrateDatabase defaultExtrasOptions dbDefinitions [numericColumnTypeTestMigration]
+
+    step "check database"
+    checkDatabase defaultExtrasOptions dbDefinitions
+
 main :: IO ()
 main = do
   defaultMainWithIngredients ings $
@@ -2650,6 +2711,7 @@ main = do
            , reservedWordColumnTests connSource
            , sqlAnyAllTests
            , enumTest connSource
+           , numericColumnTypeTest connSource
            ]
   where
     ings =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2653,6 +2653,12 @@ numericColumnTypeTestTable =
             , colCollation = Nothing
             , colNullable = False
             }
+        , tblColumn
+            { colName = "bar"
+            , colType = NumericT (Just (5, Just 0))
+            , colCollation = Nothing
+            , colNullable = False
+            }
         ]
     , tblPrimaryKey = pkOnColumn "id"
     , tblTriggers = []

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2637,25 +2637,31 @@ numericColumnTypeTestTable =
             }
         , tblColumn
             { colName = "balance"
-            , colType = NumericT Nothing
+            , colType = NumericT (Just (1000, 0))
             , colCollation = Nothing
             , colNullable = False
             }
         , tblColumn
             { colName = "employees"
-            , colType = NumericT (Just (5, Nothing))
+            , colType = NumericT (Just (5, 0))
+            , colCollation = Nothing
+            , colNullable = False
+            }
+        , tblColumn
+            { colName = "baz"
+            , colType = NumericT (Just (5, -32))
             , colCollation = Nothing
             , colNullable = False
             }
         , tblColumn
             { colName = "foo"
-            , colType = NumericT (Just (5, Just 2))
+            , colType = NumericT (Just (5, 2))
             , colCollation = Nothing
             , colNullable = False
             }
         , tblColumn
             { colName = "bar"
-            , colType = NumericT (Just (5, Just 0))
+            , colType = NumericT Nothing
             , colCollation = Nothing
             , colNullable = False
             }


### PR DESCRIPTION
We add support for defining columns of type `NUMERIC`, both in the unrestricted and restricted form, with given precision and scale.