### PR TITLE
Support renaming an existing local index during index creation migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Add support for the `NUMERIC` column type.
 * Fix getting the row estimate for `ModifyColumnMigration` if a table with the
   same name is present in multiple schemas.
+* Allow using nonreserved keywords, e.g. `timestamp`, in table indices.
+* Add support for renaming an existing local index during a migration that
+  creates index concurrently.
 
 # hpqtypes-extras-1.19.0.0 (2025-11-27)
 * Compatibility with `hpqtypes` >= 0.13.0.0.

--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -596,18 +596,18 @@ checkDBStructure options tables = fmap mconcat . forM tables $ \(table, version)
             sqlWhere "a.atthasdef"
         sqlWhere "a.attnum > 0"
         sqlWhere "NOT a.attisdropped"
-        sqlWhereEqSql "a.attrelid" $ sqlGetTableID table
+        sqlWhereEqSql "a.attrelid" $ sqlGetTableID tblName
         sqlOrderBy "a.attnum"
       desc <- fetchMany fetchTableColumn
 
       isAbove15 <- checkVersionIsAtLeast15
       -- get info about constraints from pg_catalog
-      pk <- sqlGetPrimaryKey table
-      runQuery_ $ sqlGetChecks table
+      pk <- sqlGetPrimaryKey tblName
+      runQuery_ $ sqlGetChecks tblName
       checks <- fetchMany fetchTableCheck
-      runQuery_ $ sqlGetIndexes isAbove15 table
+      runQuery_ $ sqlGetIndexes isAbove15 tblName Nothing
       indexes <- fetchMany fetchTableIndex
-      runQuery_ $ sqlGetForeignKeys table
+      runQuery_ $ sqlGetForeignKeys tblName
       fkeys <- fetchMany fetchForeignKey
       triggers <- getDBTriggers tblName
       checkedOverlaps <- checkOverlappingIndexes tblName
@@ -1126,23 +1126,43 @@ checkDBConsistency options domains enums tablesWithVersions migrations = do
               mgrDropTableMode
           runQuery_ $ sqlDelete "table_versions" $ do
             sqlWhereEq "name" (T.unpack . unRawSQL $ mgrTableName)
-        CreateIndexConcurrentlyMigration tname idx -> do
+        CreateIndexConcurrentlyMigration mLocalIndexName tableName idx -> do
           logMigration
+          indexSet <- case mLocalIndexName of
+            Nothing -> pure False
+            Just localIndexName -> do
+              isAbove15 <- checkVersionIsAtLeast15
+              runQuery_ $ sqlGetIndexes isAbove15 tableName (Just localIndexName)
+              fetchMaybe fetchTableIndex >>= \case
+                Nothing -> do
+                  logInfo_ "Local index not found"
+                  pure False
+                Just (localIdx, _) -> do
+                  when (localIdx /= idx) $ do
+                    logInfo "Local index doesn't match the definition" $
+                      object
+                        [ "index_local" .= show localIdx
+                        , "index_definition" .= show idx
+                        ]
+                    error "Indexes don't match"
+                  logInfo_ "Local index found, renaming"
+                  runQuery_ $ "ALTER INDEX" <+> localIndexName <+> "RENAME TO" <+> indexName tableName idx
+                  pure True
           -- We're in auto transaction mode (as ensured at the beginning of
           -- 'checkDBConsistency'), so we need to issue explicit SQL commit,
           -- because using 'commit' function automatically starts another
           -- transaction. We don't want that as concurrent creation of index
           -- won't run inside a transaction.
-          unsafeWithoutTransaction $ do
+          unless indexSet . unsafeWithoutTransaction $ do
             -- If migration was run before but creation of an index failed, index
             -- will be left in the database in an inactive state, so when we
             -- rerun, we need to remove it first (see
             -- https://www.postgresql.org/docs/9.6/sql-createindex.html for more
             -- information).
-            runQuery_ $ "DROP INDEX CONCURRENTLY IF EXISTS" <+> indexName tname idx
-            runQuery_ (sqlCreateIndexConcurrently tname idx)
+            runQuery_ $ "DROP INDEX CONCURRENTLY IF EXISTS" <+> indexName tableName idx
+            runQuery_ (sqlCreateIndexConcurrently tableName idx)
           updateTableVersion
-        DropIndexConcurrentlyMigration tname idx -> do
+        DropIndexConcurrentlyMigration tableName idx -> do
           logMigration
           -- We're in auto transaction mode (as ensured at the beginning of
           -- 'checkDBConsistency'), so we need to issue explicit SQL commit,
@@ -1150,7 +1170,7 @@ checkDBConsistency options domains enums tablesWithVersions migrations = do
           -- transaction. We don't want that as concurrent dropping of index
           -- won't run inside a transaction.
           unsafeWithoutTransaction $ do
-            runQuery_ (sqlDropIndexConcurrently tname idx)
+            runQuery_ (sqlDropIndexConcurrently tableName idx)
           updateTableVersion
         ModifyColumnMigration tableName cursorSql updateSql batchSize -> do
           logMigration
@@ -1416,25 +1436,25 @@ checkTableVersion tblName = do
 
 -- *** TABLE STRUCTURE ***
 
-sqlGetTableID :: Table -> SQL
-sqlGetTableID table = parenthesize . toSQLCommand $
+sqlGetTableID :: RawSQL () -> SQL
+sqlGetTableID tableName = parenthesize . toSQLCommand $
   sqlSelect "pg_catalog.pg_class c" $ do
     sqlResult "c.oid"
     sqlLeftJoinOn "pg_catalog.pg_namespace n" "n.oid = c.relnamespace"
-    sqlWhereEq "c.relname" $ tblNameString table
+    sqlWhereEq "c.relname" $ unRawSQL tableName
     sqlWhere "pg_catalog.pg_table_is_visible(c.oid)"
 
 -- *** PRIMARY KEY ***
 
 sqlGetPrimaryKey
   :: (MonadDB m, MonadThrow m)
-  => Table
+  => RawSQL ()
   -> m (Maybe (PrimaryKey, RawSQL ()))
-sqlGetPrimaryKey table = do
+sqlGetPrimaryKey tableName = do
   (mColumnNumbers :: Maybe [Int16]) <- do
     runQuery_ . sqlSelect "pg_catalog.pg_constraint" $ do
       sqlResult "conkey"
-      sqlWhereEqSql "conrelid" (sqlGetTableID table)
+      sqlWhereEqSql "conrelid" $ sqlGetTableID tableName
       sqlWhereEq "contype" 'p'
     fetchMaybe $ unArray1 . runIdentity
 
@@ -1446,14 +1466,14 @@ sqlGetPrimaryKey table = do
           runQuery_ . sqlSelect "pk_columns" $ do
             sqlWith "key_series" . sqlSelect "pg_constraint as c2" $ do
               sqlResult "unnest(c2.conkey) as k"
-              sqlWhereEqSql "c2.conrelid" $ sqlGetTableID table
+              sqlWhereEqSql "c2.conrelid" $ sqlGetTableID tableName
               sqlWhereEq "c2.contype" 'p'
 
             sqlWith "pk_columns" . sqlSelect "key_series" $ do
               sqlJoinOn "pg_catalog.pg_attribute as a" "a.attnum = key_series.k"
               sqlResult "a.attname::text as column_name"
               sqlResult "key_series.k as column_order"
-              sqlWhereEqSql "a.attrelid" $ sqlGetTableID table
+              sqlWhereEqSql "a.attrelid" $ sqlGetTableID tableName
 
             sqlResult "pk_columns.column_name"
             sqlWhereEq "pk_columns.column_order" k
@@ -1462,7 +1482,7 @@ sqlGetPrimaryKey table = do
 
       runQuery_ . sqlSelect "pg_catalog.pg_constraint as c" $ do
         sqlWhereEq "c.contype" 'p'
-        sqlWhereEqSql "c.conrelid" $ sqlGetTableID table
+        sqlWhereEqSql "c.conrelid" $ sqlGetTableID tableName
         sqlResult "c.conname::text"
         sqlResult $
           Data.String.fromString
@@ -1477,15 +1497,15 @@ fetchPrimaryKey (name, Array1 columns) =
 
 -- *** CHECKS ***
 
-sqlGetChecks :: Table -> SQL
-sqlGetChecks table = toSQLCommand . sqlSelect "pg_catalog.pg_constraint c" $ do
+sqlGetChecks :: RawSQL () -> SQL
+sqlGetChecks tableName = toSQLCommand . sqlSelect "pg_catalog.pg_constraint c" $ do
   sqlResult "c.conname::text"
   sqlResult
     "regexp_replace(pg_get_constraintdef(c.oid, true), \
     \'CHECK \\((.*)\\)', '\\1') AS body" -- check body
   sqlResult "c.convalidated" -- validated?
   sqlWhereEq "c.contype" 'c'
-  sqlWhereEqSql "c.conrelid" $ sqlGetTableID table
+  sqlWhereEqSql "c.conrelid" $ sqlGetTableID tableName
 
 fetchTableCheck :: (Text, Text, Bool) -> Check
 fetchTableCheck (name, condition, validated) =
@@ -1496,8 +1516,8 @@ fetchTableCheck (name, condition, validated) =
     }
 
 -- *** INDEXES ***
-sqlGetIndexes :: Bool -> Table -> SQL
-sqlGetIndexes nullsNotDistinctSupported table = toSQLCommand . sqlSelect "pg_catalog.pg_class c" $ do
+sqlGetIndexes :: Bool -> RawSQL () -> Maybe (RawSQL ()) -> SQL
+sqlGetIndexes nullsNotDistinctSupported tableName mname = toSQLCommand . sqlSelect "pg_catalog.pg_class c" $ do
   sqlResult "c.relname::text" -- index name
   sqlResult $ "ARRAY(" <> selectCoordinates "0" "i.indnkeyatts" <> ")" -- array of key columns in the index
   sqlResult $ "ARRAY(" <> selectCoordinates "i.indnkeyatts" "i.indnatts" <> ")" -- array of included columns in the index
@@ -1518,8 +1538,9 @@ sqlGetIndexes nullsNotDistinctSupported table = toSQLCommand . sqlSelect "pg_cat
   -- weren't successfully built by it) are marked as invalid, so we don't want
   -- to consider them at a time.
   sqlWhere "i.indisvalid"
-  sqlWhereEqSql "i.indrelid" $ sqlGetTableID table
+  sqlWhereEqSql "i.indrelid" $ sqlGetTableID tableName
   sqlWhereIsNULL "r.contype" -- fetch only "pure" indexes
+  forM_ mname $ sqlWhereEq "c.relname" . unRawSQL
   where
     -- Get all coordinates of the index.
     selectCoordinates start end =
@@ -1554,8 +1575,8 @@ fetchTableIndex (name, Array1 keyColumns, Array1 includeColumns, method, unique,
 
 -- *** FOREIGN KEYS ***
 
-sqlGetForeignKeys :: Table -> SQL
-sqlGetForeignKeys table = toSQLCommand
+sqlGetForeignKeys :: RawSQL () -> SQL
+sqlGetForeignKeys tableName = toSQLCommand
   . sqlSelect "pg_catalog.pg_constraint r"
   $ do
     sqlResult "r.conname::text" -- fk name
@@ -1579,7 +1600,7 @@ sqlGetForeignKeys table = toSQLCommand
     sqlResult "r.condeferred" -- initially deferred?
     sqlResult "r.convalidated" -- validated?
     sqlJoinOn "pg_catalog.pg_class c" "c.oid = r.confrelid"
-    sqlWhereEqSql "r.conrelid" $ sqlGetTableID table
+    sqlWhereEqSql "r.conrelid" $ sqlGetTableID tableName
     sqlWhereEq "r.contype" 'f'
   where
     unnestWithOrdinality :: RawSQL () -> SQL

--- a/src/Database/PostgreSQL/PQTypes/Model/Migration.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Migration.hs
@@ -46,6 +46,15 @@ data MigrationAction m
     DropTableMigration DropTableMode
   | -- | Migration for creating an index concurrently.
     CreateIndexConcurrentlyMigration
+      (Maybe (RawSQL ()))
+      -- ^ Optional name of the local index that, if exists, will be renamed to
+      -- the desired index instead of creating it from scratch.
+      --
+      -- - If the index doesn't exist, the migration will proceed as usual and
+      --  create the index from scratch.
+      --
+      -- - If the index exists and its structure doesn't match the desired
+      --   index, the migration will abort with an error.
       (RawSQL ())
       -- ^ Table name
       TableIndex

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -147,19 +147,35 @@ tableBankMigration5snd =
     , mgrFrom = 3
     , mgrAction =
         CreateIndexConcurrentlyMigration
+          (Just "local_idx_doesnt_exist")
           (tblName tableBankSchema3)
           ((indexOnColumn "name") {idxInclude = ["id", "location"]})
+    }
+
+tableBankMigration5thrd :: MonadDB m => Migration m
+tableBankMigration5thrd =
+  Migration
+    { mgrTableName = tblName tableBankSchema3
+    , mgrFrom = 4
+    , mgrAction =
+        CreateIndexConcurrentlyMigration
+          (Just localBankIndexToRename)
+          (tblName tableBankSchema3)
+          (indexOnColumns ["id", "name"])
     }
 
 tableBankSchema5 :: Table
 tableBankSchema5 =
   tableBankSchema4
-    { tblVersion = tblVersion tableBankSchema4 + 2
+    { tblVersion = tblVersion tableBankSchema4 + 3
     , tblColumns =
         filter
           (\c -> colName c /= "cash")
           (tblColumns tableBankSchema4)
-    , tblIndexes = [(indexOnColumn "name") {idxInclude = ["id", "location"]}]
+    , tblIndexes =
+        [ (indexOnColumn "name") {idxInclude = ["id", "location"]}
+        , indexOnColumns ["id", "name"]
+        ]
     }
 
 tableBadGuySchema1 :: Table
@@ -557,6 +573,7 @@ schema5Migrations =
     ++ [ createTableMigration tableFlash
        , tableBankMigration5fst
        , tableBankMigration5snd
+       , tableBankMigration5thrd
        , dropTableMigration tableFlash
        ]
 
@@ -589,6 +606,9 @@ schema6Migrations =
 
 type TestM a = DBT (LogT IO) a
 
+localBankIndexToRename :: RawSQL ()
+localBankIndexToRename = "local_idx_bank_id_name"
+
 createTablesSchema1 :: (String -> TestM ()) -> TestM ()
 createTablesSchema1 step = do
   let definitions = tableDefsWithPgCrypto schema1Tables
@@ -597,6 +617,9 @@ createTablesSchema1 step = do
 
   -- Add a local index that shouldn't trigger validation errors.
   runSQL_ "CREATE INDEX local_idx_bank_name ON bank(name)"
+
+  -- Add a local index that will be renamed during a migration later.
+  runQuery_ $ "CREATE INDEX" <+> localBankIndexToRename <+> "ON bank(id, name)"
 
   checkDatabase defaultExtrasOptions definitions
 


### PR DESCRIPTION
I'm not sure whether the migration should
- abort if the local index pointed to in the migration exists, but doesn't match the index that is wanted, or
- proceed with the creation as usual and ignore the local index if it doesn't match.

There are pros and cons of both approaches.

- If we proceed, then no manual intervention is needed, but on the other hand the migration can take a long time on a large table and we'll be kinda stuck waiting for it to finish.
- If we abort, then manual intervention is needed and update potentially needs to be postponed, but we won't be stuck waiting for a migration to finish (for a few hours in a pessimistic scenario?).

@marco44 thoughts?

I went back and forth while writing code, ended up with the "proceed" route for now, but I'm not sure if it's best.

