### PR TITLE
Document non-reserved keyword behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 * Adds a `Function` datatype and a `defaultTriggerFunction` backwards-compatible
   trigger function helper.
 * Remove `Read` instance of `IndexMethod`.
-* Allow using nonreserved keywords, e.g. `timestamp`, in table indices.
 * Add support for the `NUMERIC` column type.
 * Fix getting the row estimate for `ModifyColumnMigration` if a table with the
   same name is present in multiple schemas.

--- a/src/Database/PostgreSQL/PQTypes/Checks.hs
+++ b/src/Database/PostgreSQL/PQTypes/Checks.hs
@@ -1539,8 +1539,8 @@ fetchTableIndex
   -> (TableIndex, RawSQL ())
 fetchTableIndex (name, Array1 keyColumns, Array1 includeColumns, method, unique, nullsNotDistinct, mconstraint) =
   ( TableIndex
-      { idxColumns = map (indexColumn . (`rawSQL` ()) . stripIdentifierQuotes) keyColumns
-      , idxInclude = map ((`rawSQL` ()) . stripIdentifierQuotes) includeColumns
+      { idxColumns = map (indexColumn . (`rawSQL` ())) keyColumns
+      , idxInclude = map (`rawSQL` ()) includeColumns
       , idxMethod = case method of
           "gin" -> GIN
           "btree" -> BTree
@@ -1551,10 +1551,6 @@ fetchTableIndex (name, Array1 keyColumns, Array1 includeColumns, method, unique,
       }
   , rawSQL name ()
   )
-  where
-    stripIdentifierQuotes str = case fmap T.unsnoc <$> T.uncons str of
-      Just ('"', Just (identifier, '"')) -> identifier
-      _ -> str
 
 -- *** FOREIGN KEYS ***
 

--- a/src/Database/PostgreSQL/PQTypes/Model/Index.hs
+++ b/src/Database/PostgreSQL/PQTypes/Model/Index.hs
@@ -65,6 +65,16 @@ instance Ord IndexColumn where
 instance IsString IndexColumn where
   fromString s = IndexColumn (fromString s) Nothing
 
+-- | Build an 'IndexColumn' from a column name.
+--
+-- If the column name is a non-reserved keyword in PostgreSQL it must be given
+-- double-quoted, e.g.
+--
+--   @timestamp@ -> @\"\\\"timestamp\\\"\"@
+--
+-- PostgreSQL stores the index definition with the keyword quoted, so the column
+-- name passed here has to match that exactly or the database consistency check
+-- will report a mismatch.
 indexColumn :: RawSQL () -> IndexColumn
 indexColumn col = IndexColumn col Nothing
 
@@ -166,6 +176,7 @@ indexName tname TableIndex {..} =
     asText f = flip rawSQL () . f . unRawSQL
     -- See http://www.postgresql.org/docs/9.4/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS.
     -- Remove all unallowed characters and replace them by at most one adjacent dollar sign.
+    -- NB: This allows the behavior as described in @indexColumn@.
     sanitize = T.pack . foldr go [] . T.unpack
       where
         go c acc =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2325,102 +2325,6 @@ nullsNotDistinctTests connSource = do
             ]
         }
 
-reservedWordColumnTests :: ConnectionSourceM (LogT IO) -> TestTree
-reservedWordColumnTests connSource =
-  testCaseSteps' "Reserved word column tests" connSource $ \step -> do
-    freshTestDB step
-
-    step "Create a table with a plain index on a 'timestamp' column"
-    assertNoException "Table with index on 'timestamp' column should be created successfully" $ do
-      let definitions = tableDefsWithPgCrypto [tableWithTimestampIndex]
-      migrateDatabase
-        defaultExtrasOptions
-        definitions
-        [createTableMigration tableWithTimestampIndex]
-      checkDatabase defaultExtrasOptions definitions
-
-    freshTestDB step
-
-    step "Create a table with a unique index on a 'timestamp' column"
-    assertNoException "Table with unique index on 'timestamp' column should be created successfully" $ do
-      let definitions = tableDefsWithPgCrypto [tableWithUniqueTimestampIndex]
-      migrateDatabase
-        defaultExtrasOptions
-        definitions
-        [createTableMigration tableWithUniqueTimestampIndex]
-      checkDatabase defaultExtrasOptions definitions
-
-    freshTestDB step
-
-    step "Create a table with a composite index including a 'timestamp' column"
-    assertNoException "Table with composite index on 'timestamp' column should be created successfully" $ do
-      let definitions = tableDefsWithPgCrypto [tableWithCompositeTimestampIndex]
-      migrateDatabase
-        defaultExtrasOptions
-        definitions
-        [createTableMigration tableWithCompositeTimestampIndex]
-      checkDatabase defaultExtrasOptions definitions
-
-    freshTestDB step
-
-    step "Attempt to create a table with an index on a 'select' column"
-    assertException "Table with index on 'select' column can't be created" $ do
-      let definitions = tableDefsWithPgCrypto [tableWithSelectIndex]
-      migrateDatabase
-        defaultExtrasOptions
-        definitions
-        [createTableMigration tableWithSelectIndex]
-      checkDatabase defaultExtrasOptions definitions
-  where
-    tableWithTimestampIndex =
-      tblTable
-        { tblName = "reserved_word_test1"
-        , tblVersion = 1
-        , tblColumns =
-            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
-            , tblColumn {colName = "timestamp", colType = TimestampWithZoneT, colNullable = False}
-            ]
-        , tblPrimaryKey = pkOnColumn "id"
-        , tblIndexes = [indexOnColumn "timestamp"]
-        }
-
-    tableWithUniqueTimestampIndex =
-      tblTable
-        { tblName = "reserved_word_test2"
-        , tblVersion = 1
-        , tblColumns =
-            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
-            , tblColumn {colName = "timestamp", colType = TimestampWithZoneT, colNullable = False}
-            ]
-        , tblPrimaryKey = pkOnColumn "id"
-        , tblIndexes = [uniqueIndexOnColumn "timestamp"]
-        }
-
-    tableWithCompositeTimestampIndex =
-      tblTable
-        { tblName = "reserved_word_test3"
-        , tblVersion = 1
-        , tblColumns =
-            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
-            , tblColumn {colName = "timestamp", colType = TimestampWithZoneT, colNullable = False}
-            , tblColumn {colName = "name", colType = TextT, colNullable = True}
-            ]
-        , tblPrimaryKey = pkOnColumn "id"
-        , tblIndexes = [indexOnColumns [indexColumn "timestamp", indexColumn "name"]]
-        }
-
-    tableWithSelectIndex =
-      tblTable
-        { tblName = "reserved_word_test4"
-        , tblVersion = 1
-        , tblColumns =
-            [ tblColumn {colName = "id", colType = UuidT, colNullable = False, colDefault = Just "gen_random_uuid()"}
-            , tblColumn {colName = "select", colType = TextT, colNullable = True}
-            ]
-        , tblPrimaryKey = pkOnColumn "id"
-        , tblIndexes = [indexOnColumn "select"]
-        }
-
 sqlAnyAllTests :: TestTree
 sqlAnyAllTests =
   testGroup
@@ -2720,7 +2624,6 @@ main = do
            , foreignKeyIndexesTests connSource
            , overlapingIndexesTests connSource
            , nullsNotDistinctTests connSource
-           , reservedWordColumnTests connSource
            , sqlAnyAllTests
            , enumTest connSource
            , numericColumnTypeTest connSource


### PR DESCRIPTION
Reverts the change in #136, which had an existing undocumented alternative. Adds a comment to `indexColumn` so the behavior is easier to be aware of. 